### PR TITLE
Final filtering addition

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -13,17 +13,22 @@ class Filter {
     this.list = new List(this.$el.id, {
       valueNames: this.sortOptions.map(o => o.name)
     })
+    /** Hide "open for both" filter */
+    this.$filters[2].parentElement.style.display = 'none'
   }
 
   update() {
     const sortSettings = _.find(this.sortOptions, o => (o.name === this.$sort.value))
     let filterValues = this.$filters.map(f => f.checked)
-    /** if "open for receiving donations" (item 0) or "open for distributing donations" (item 2)
-     * is checked, then "open for both" (item 3) information should be automatically displayed as well.
+    /** if "open for receiving donations" (item 0) or "open for distributing donations" (item 1)
+     * is checked, then items categorized as "open for both" (item 2) information should be
+     * automatically displayed as well.
      */
     if (filterValues[0] === true || filterValues[1] === true) {
       filterValues[2] = true
-      this.$filters[2].checked = true
+    }
+    if (!filterValues[0] && !filterValues[1]) {
+      filterValues[2] = false
     }
 
     this.list.filter(i => {

--- a/filter.js
+++ b/filter.js
@@ -17,7 +17,14 @@ class Filter {
 
   update() {
     const sortSettings = _.find(this.sortOptions, o => (o.name === this.$sort.value))
-    const filterValues = this.$filters.map(f => f.checked)
+    let filterValues = this.$filters.map(f => f.checked)
+    /** if "open for receiving donations" (item 0) or "open for distributing donations" (item 2)
+     * is checked, then "open for both" (item 3) information should be automatically displayed as well.
+     */
+    if (filterValues[0] === true || filterValues[1] === true) {
+      filterValues[2] = true
+      this.$filters[2].checked = true
+    }
 
     this.list.filter(i => {
         const index = _.findIndex(this.statusOptions, o => (o.id === i.values().status))


### PR DESCRIPTION
Addresses remaining todo in [filtering additions issue](https://github.com/jdalt/twin-cities-aid-distribution-locations/issues/21) in old repo. 

if "open for receiving donations" or "open for distributing donations" (item 2) is checked, then spots that are "open for both" should be automatically displayed as well.

Current solution may create a weird UX thing where if someone tries to uncheck "open for both" when one of the other two "open" options are selected, they won't be able to. Options to address this: I can leave it how it is, let people uncheck "open for both" even when one of the other two "open" options are selected (what might that use case be though?), or hide "open for both" from the filtering menu (but still leave it as an item in the map's key). 