### PR TITLE
show "open for both" color on receiving/distributing filter buttons

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -14,8 +14,7 @@ class Filter {
       valueNames: this.sortOptions.map(o => o.name)
     })
     /** Hide "open for both" filter */
-    // this.$filters[2].parentElement.style.display = 'none'
-    document.getElementById("filter-both").style.opacity = 0;
+    document.getElementById("filter-both").parentElement.style.display = 'none';
   }
 
   update() {
@@ -61,7 +60,12 @@ class Filter {
 
 
     const filters = this.statusOptions.map(s => {
-      return `<li class='filter-item'><input class="filter" type="checkbox" id="filter-${s.name}" value="${s.name}" checked><span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span><label for="filter-${s.name}">${s.label}</label></li>`
+      /** Open for receiving / distributing donations should have two colors */
+      if (s.accessibleColor === "#2c7bb6" || s.accessibleColor === "#abd9e9") {
+        return `<li class='filter-item'><input class="filter" type="checkbox" id="filter-${s.name}" value="${s.name}" checked><span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span>/<span class="legend--item--swatch" style="background-color: #fdae61"></span><label for="filter-${s.name}">${s.label}</label></li>`
+      } else {
+        return `<li class='filter-item'><input class="filter" type="checkbox" id="filter-${s.name}" value="${s.name}" checked><span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span><label for="filter-${s.name}">${s.label}</label></li>`
+      }
     }).join('')
 
     this.$controls.innerHTML = `

--- a/script.js
+++ b/script.js
@@ -268,6 +268,16 @@ const key = document.getElementById('key')
 statusOptions.forEach(s => {
   const el = document.createElement('div');
   el.classList = ['legend--item'];
-  el.innerHTML = `<span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span>${s.label}`
+  if (s.accessibleColor === "#2c7bb6" || s.accessibleColor === "#abd9e9") {
+    el.innerHTML = `<span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span> / <span class="legend--item--swatch" style="background-color: #fdae61"></span>${s.label}`
+  } else {
+    el.innerHTML = `<span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span>${s.label}`
+  }
   key.append(el)
 })
+
+/*
+  if ($item.dataset.id === "filter-recieving" || $item.dataset.id === "filter-distributing") {
+    const span = `<span title="${status.id}" class="status location-list--indicator" style="background-color: ${status.accessibleColor};">${status.id}</span>`;
+  };
+*/

--- a/styles.css
+++ b/styles.css
@@ -158,6 +158,14 @@ input[type='checkbox'] + label {
   margin-left: 5px;
 }
 
+label[for="filter-both"] { /* hide filter both option during load. */
+  display: none;
+}
+
+#filter-both {
+  display: none;
+}
+
 /* component: location list */
 .location-list {
   padding: 15px;


### PR DESCRIPTION
In response to conversation in Slack with @comeoneileen @jasonthibeault, added the orange "open for both" color alongside the "open for receiving" and "open for distributing" colors in the filtering / legend area. Also hid the "open for both" filtering option. 

Currently: 
![Screen Shot 2020-06-03 at 5 52 55 PM](https://user-images.githubusercontent.com/23054741/83696831-13f12d00-a5c3-11ea-8826-7a073e50d04f.png)

Previously:
![image](https://user-images.githubusercontent.com/23054741/83697131-d04af300-a5c3-11ea-9b66-1d262efc91d1.png)