### PR TITLE
Standardize the typography for links

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.5.1/mapbox-gl-geocoder.min.js"></script>
   <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.5.1/mapbox-gl-geocoder.css" type="text/css" />
   <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
-	
+
 	<!-- CONFIG -->
 	<script>
 		mapboxgl.accessToken = 'pk.eyJ1IjoiamFjb2JyZGFsdG9uIiwiYSI6ImNrYXc2anFjbjIxNGwyeG14dWk0MDVycmIifQ.yILWplracVMB4mv1dWwTtg'
@@ -42,13 +42,14 @@
   <div class="content">
     <div class="title">
       <h1 class='h1'>Twin Cities Aid Map</h1>
-      <p class='p txt-small spaced-lines'>See this data in <a class="txt-white" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>. About <a class="txt-white" href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations" target="_blank">this project</a>.</p>
+      <p class='p txt-small spaced-lines'>See this data in <a class="txt-white" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
       <div class='legend' id="key"></div>
       <button id="toggle-button" class="location-list-toggle" onClick="toggleSidePane(this)">Show list of locations</button>
       <div class='counter'>
         <script type="text/javascript" src="//counter.websiteout.net/js/7/0/41000/0"></script>
       </div>
-      <p class='p txt-small spaced-lines'>Seeing Issues? <a class="txt-white" href="mailto:support@tcmap.org">Email Us</a></p>
+      <p class='p txt-small spaced-lines'>Seeing Issues? <a class="txt-white" href="mailto:support@tcmap.org">Email Us</a>.</p>
+      <p class='p txt-small spaced-lines'>Learn about this project on <a class="txt-white" href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
     </div>
     <div id="side-pane" class="location-list">
       <div id="filter-controls"></div>
@@ -56,7 +57,7 @@
     </div>
   </div>
   <div class='map' id="map"></div>
-  
+
   <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
   <script src="./filter.js"></script>
   <script src="./script.js"></script>

--- a/index.html
+++ b/index.html
@@ -42,14 +42,14 @@
   <div class="content">
     <div class="title">
       <h1 class='h1'>Twin Cities Aid Map</h1>
-      <p class='p txt-small spaced-lines'>See this data in <a class="txt-white" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
+      <p class='p txt-small'>See this data in <a class="txt-white" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
       <div class='legend' id="key"></div>
       <button id="toggle-button" class="location-list-toggle" onClick="toggleSidePane(this)">Show list of locations</button>
       <div class='counter'>
         <script type="text/javascript" src="//counter.websiteout.net/js/7/0/41000/0"></script>
       </div>
-      <p class='p txt-small spaced-lines'>Seeing Issues? <a class="txt-white" href="mailto:support@tcmap.org">Email Us</a>.</p>
-      <p class='p txt-small spaced-lines'>Learn about this project on <a class="txt-white" href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
+      <p class='p txt-small'>Seeing Issues? <a class="txt-white" href="mailto:support@tcmap.org">Email Us</a>.</p>
+      <p class='p txt-small'>Learn about this project on <a class="txt-white" href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
     </div>
     <div id="side-pane" class="location-list">
       <div id="filter-controls"></div>

--- a/styles.css
+++ b/styles.css
@@ -220,6 +220,7 @@ input[type='checkbox'] + label {
   background-color: rgba(255,255,255,.75);
   border-radius: 3px;
   display: none;
+  margin-bottom: 1em;
 }
 
 .location-list-toggle:hover {

--- a/styles.css
+++ b/styles.css
@@ -8,8 +8,8 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  margin: 0; 
-  padding: 0; 
+  margin: 0;
+  padding: 0;
   overflow: hidden;
   font: 15px/1.4 Arial, Helvetica, sans-serif;
 }
@@ -26,13 +26,13 @@ a.txt-white:hover {
   color: royalblue
 }
 
-.map { 
+.map {
   left: 0;
   top: 0;
-  right: 0; 
+  right: 0;
   bottom: 0;
   height: 100%;
-  width: 100%; 
+  width: 100%;
 }
 
 .content {
@@ -55,7 +55,7 @@ a.txt-white:hover {
 }
 
 /* Shared:typography */
-.h1 { 
+.h1 {
   font: bold 20px/1.2 Arial, Helvetica, sans-serif;
   margin-top: 0px;
 }
@@ -64,7 +64,7 @@ a.txt-white:hover {
   margin-bottom: 10px;
 }
 
-.h2 { 
+.h2 {
   font: bold 15px/1.2 Arial, Helvetica, sans-serif;
   margin: 0;
 }
@@ -73,7 +73,7 @@ a.txt-white:hover {
   margin-bottom: 5px;
 }
 
-.h3 { 
+.h3 {
   font:bold 12px/1.2 Arial, Helvetica, sans-serif;
   color: rgba(0,0,0,.5);
   text-transform: uppercase;
@@ -100,10 +100,6 @@ a.txt-white:hover {
   opacity: .75;
 }
 
-.spaced-lines {
-  line-height: 1.7rem;
-}
-
 /* Shared:forms */
 input[type='checkbox'] + label {
   margin-left: 5px;
@@ -114,7 +110,7 @@ input[type='checkbox'] + label {
   margin-bottom: 10px;
 }
 
-.select-container select { 
+.select-container select {
   border-radius: 5px;
   margin-left: 10px;
   width: 150px;
@@ -149,7 +145,7 @@ input[type='checkbox'] + label {
   align-items: center;
 }
 
-.legend--item--swatch { 
+.legend--item--swatch {
   border-radius: 20%;
   width: 10px;
   height: 10px;
@@ -257,7 +253,7 @@ input[type='checkbox'] + label {
   min-width: 30px !important;
   height: 30px !important;
 }
-.mapboxgl-ctrl-geocoder--icon-search { 
+.mapboxgl-ctrl-geocoder--icon-search {
   fill: black;
   left: 4px !important;
   top: 4px !important;
@@ -279,7 +275,7 @@ input[type='checkbox'] + label {
   body {
     flex-direction: column;
   }
-  .content { 
+  .content {
     width: 100%;
   }
   .legend {
@@ -290,7 +286,7 @@ input[type='checkbox'] + label {
     margin-right: 10px;
   }
 
-  .location-list-toggle { 
+  .location-list-toggle {
     display: block;
   }
 
@@ -304,7 +300,7 @@ input[type='checkbox'] + label {
   .map {
     display: block;
   }
-  .list-active .map { 
+  .list-active .map {
     display: none;
   }
 


### PR DESCRIPTION
- Use verbs at the beginning of each phrase.
- Use `.` at the end of each phrase.
- Namedrop GitHub like we namedrop Google Sheets.
- Put GitHub link on its own line, after the email link.
- Make GitHub link to the README.md rather than the repository root for easier reading by people less familiar with GitHub.
- Autoremove some unneeded whitespace.

Before:

<img width="318" alt="image" src="https://user-images.githubusercontent.com/969868/83699969-1fe0ed00-a5cb-11ea-82c9-17edcdf90c91.png">


After:

<img width="318" alt="image" src="https://user-images.githubusercontent.com/969868/83699964-1a83a280-a5cb-11ea-8bc4-4dfa07fab51b.png">

