### PR TITLE
Reduce title area height on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,21 +44,24 @@
       <h1 class='h1'>Twin Cities Aid Map</h1>
     </div>
     <div class="filter-pane white-and-blue">
-      <p class='p txt-small'>See this data in <a class="txt-white" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
       <div class='legend' id="key"></div>
-      <button id="toggle-button" class="location-list-toggle" onClick="toggleSidePane(this)">Show list of locations</button>
+      <button id="locations-toggle-button" class="location-list-toggle toggle-button" onClick="toggleSidePane(this)">Show list of locations</button>
+      <a href='#help-info'><button id="help-info-toggle-button" class="toggle-button" onClick="toggleHelpInfo(this)">Help/info</button></a>
       <div class='counter'>
         <script type="text/javascript" src="//counter.websiteout.net/js/7/0/41000/0"></script>
       </div>
-      <p class='p txt-small'>Seeing Issues? <a class="txt-white" href="mailto:support@tcmap.org">Email Us</a>.</p>
-      <p class='p txt-small'>Learn about this project on <a class="txt-white" href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
     </div>
     <div id="side-pane" class="location-list">
       <div id="filter-controls"></div>
       <div class="list" id="location-list"></div>
     </div>
   </div>
-
+  <div id="help-info" class='help-info padded'>
+    <p class='p txt-small'>Twin Cities Aid Map is run by volunteers.</p><br />
+    <p class='p txt-small'>Have feedback? <a href="mailto:support@tcmap.org">Email Us</a>.</p>
+    <p class='p txt-small'>See this data in <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
+    <p class='p txt-small'>Learn about this project on <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
+  </div>
   <div class='map' id="map"></div>
 
   <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
     </div>
     <div class="filter-pane white-and-blue">
       <div class='legend' id="key"></div>
-      <button id="locations-toggle-button" class="location-list-toggle toggle-button" onClick="toggleSidePane(this)">Show list of locations</button>
-      <a href='#help-info'><button id="help-info-toggle-button" class="toggle-button" onClick="toggleHelpInfo(this)">Help/info</button></a>
+      <button id="locations-toggle-button" class="location-list-toggle toggle-button" onClick="toggleSidePane(this)" aria-label="Toggle list of locations">Show list of locations</button>
+      <button id="help-info-toggle-button" class="toggle-button" onClick="toggleHelpInfo(this)" aria-label="Toggle help info section">Help/info</button>
       <div class='counter'>
         <script type="text/javascript" src="//counter.websiteout.net/js/7/0/41000/0"></script>
       </div>
@@ -56,11 +56,12 @@
       <div class="list" id="location-list"></div>
     </div>
   </div>
-  <div id="help-info" class='help-info padded'>
+  <div id="help-info" class='help-info padded spaced-lines'>
+    <button class='help-info-close-button' onClick="toggleHelpInfo(this)" aria-label="Close help info section">X Close</button>
     <p class='p txt-small'>Twin Cities Aid Map is run by volunteers.</p><br />
-    <p class='p txt-small'>Have feedback? <a href="mailto:support@tcmap.org">Email Us</a>.</p>
-    <p class='p txt-small'>See this data in <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
-    <p class='p txt-small'>Learn about this project on <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
+    <p class='p txt-small bold'>Have feedback? <a href="mailto:support@tcmap.org">Email Us</a>.</p>
+    <p class='p txt-small bold'>See this data in <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
+    <p class='p txt-small bold'>Learn about this project on <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
   </div>
   <div class='map' id="map"></div>
 

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 const $locationList = document.getElementById('location-list')
 const $sidePane = document.getElementById('side-pane')
-const $button = document.getElementById('toggle-button');
+const $locationsButton = document.getElementById('locations-toggle-button');
 const $body = document.body;
 
 
@@ -89,10 +89,10 @@ function camelToTitle(str) {
 // open/close sidebar
 function toggleSidePane() {
   if ($body.classList.contains('list-active')) {
-    $button.innerText = 'Show list of locations'
+    $locationsButton.innerText = 'Show list of locations'
     $body.classList.remove('list-active')
   } else {
-    $button.innerText = 'Hide list of locations'
+    $locationsButton.innerText = 'Hide list of locations'
     $body.classList.add('list-active')
   }
 }

--- a/script.js
+++ b/script.js
@@ -29,7 +29,7 @@ const statusOptions = [
   {
     id: '#c70000',
     name: 'closed',
-    label: 'confirmed closed',
+    label: 'currently closed',
     accessibleColor: '#d7191c'
   },
   {
@@ -86,7 +86,7 @@ function camelToTitle(str) {
   return result.charAt(0).toUpperCase() + result.slice(1)
 }
 
-// open/close sidebar
+// open/close location sidebar
 function toggleSidePane() {
   if ($body.classList.contains('list-active')) {
     $locationsButton.innerText = 'Show list of locations'
@@ -94,6 +94,17 @@ function toggleSidePane() {
   } else {
     $locationsButton.innerText = 'Hide list of locations'
     $body.classList.add('list-active')
+  }
+}
+
+// open/close help info
+function toggleHelpInfo() {
+  if (window.location.hash === '#help-info') {
+    // this currently leaves a '#' at the end of the URL on close. there's definitely a
+    // better solution out there, but this works even if it's not pretty
+    window.location.hash = ''
+  } else {
+    window.location.hash = '#help-info'
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -26,13 +26,22 @@ a.txt-white:hover {
   color: royalblue
 }
 
-.map {
+.map,
+.help-info {
   left: 0;
   top: 0;
   right: 0;
   bottom: 0;
   height: 100%;
   width: 100%;
+}
+
+.help-info:target {
+  display: block;
+}
+
+.help-info:not(:target) {
+  display: none;
 }
 
 .content {
@@ -100,6 +109,30 @@ a.txt-white:hover {
 .txt-deemphasize {
   opacity: 0.70;
   font-size: 0.9em;
+}
+
+.padded {
+  padding: 15px;
+}
+
+/* shared: buttons */
+.toggle-button {
+  padding: 5px 10px;
+  border: none;
+  color: black;
+  display: inline-block;
+  background-color: rgba(255,255,255,.75);
+  border-radius: 3px;
+  margin-right: 0.67em;
+}
+
+.toggle-button:hover {
+  cursor: pointer;
+  background-color: white;
+}
+
+.toggle-button:last-child {
+  margin-right: 0;
 }
 
 /* Shared:forms */
@@ -214,18 +247,7 @@ input[type='checkbox'] + label {
 
 /* component: location list toggle */
 .location-list-toggle {
-  padding: 5px 10px;
-  border: none;
-  color: black;
-  background-color: rgba(255,255,255,.75);
-  border-radius: 3px;
   display: none;
-  margin-bottom: 1em;
-}
-
-.location-list-toggle:hover {
-  cursor: pointer;
-  background-color: white;
 }
 
 /* component: map popup */
@@ -312,7 +334,7 @@ input[type='checkbox'] + label {
     margin-right: 10px;
   }
   .location-list-toggle {
-    display: block;
+    display: inline-block;
   }
   .list-active .location-list {
     display: block;
@@ -325,5 +347,8 @@ input[type='checkbox'] + label {
   }
   .list-active .map {
     display: none;
+  }
+  .h1 {
+    margin: 0;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,10 @@ a.txt-white:hover {
   display: none;
 }
 
+.help-info:target + .map {
+  display: none;
+}
+
 .content {
   z-index: 1;
   width: 33.3333%;
@@ -109,6 +113,10 @@ a.txt-white:hover {
 .txt-deemphasize {
   opacity: 0.70;
   font-size: 0.9em;
+}
+
+.bold {
+  font-weight: 600;
 }
 
 .padded {
@@ -250,6 +258,17 @@ input[type='checkbox'] + label {
   display: none;
 }
 
+/* component: help info close button */
+.help-info-close-button {
+  display: inline;
+  float: right;
+  margin-top: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 13px;
+  padding: 5px 10px;
+}
+
 /* component: map popup */
 .popup-content {
   padding: 15px;
@@ -350,5 +369,8 @@ input[type='checkbox'] + label {
   }
   .h1 {
     margin: 0;
+  }
+  .help-info-close-button {
+    margin-top: 0;
   }
 }


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.
-->

### What
Reduce height of the title area on mobile. Break help/info out into it's own separate section and conditionally show/hide it when user clicks the button.

### Why
Title area takes up too much vertical space on small screens. Issue: https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/issues/57

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

**Desktop screenshots**

<img width="895" alt="Screen Shot 2020-06-04 at 2 06 38 PM" src="https://user-images.githubusercontent.com/2946681/83800230-bb766a00-a66c-11ea-9065-ed413af1c3ac.png">

<img width="895" alt="Screen Shot 2020-06-04 at 2 06 46 PM" src="https://user-images.githubusercontent.com/2946681/83800236-bfa28780-a66c-11ea-9127-920bab691359.png">

**Mobile screenshots** (iPhone 5/SE size)

<img width="337" alt="Screen Shot 2020-06-04 at 2 06 57 PM" src="https://user-images.githubusercontent.com/2946681/83800261-c9c48600-a66c-11ea-9ebc-465ed45619ed.png">

<img width="331" alt="Screen Shot 2020-06-04 at 2 07 03 PM" src="https://user-images.githubusercontent.com/2946681/83800284-d3e68480-a66c-11ea-8d66-9e1f467b5352.png">
