### PR TITLE
simplest "open for both" checkbox fix

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -13,9 +13,11 @@ class Filter {
     this.list = new List(this.$el.id, {
       valueNames: this.sortOptions.map(o => o.name)
     })
-    /** Hide "open for both" filter */
-    // this.$filters[2].parentElement.style.display = 'none'
-    document.getElementById("filter-both").style.opacity = 0;
+    /** Default filter-both checkbox to be disabled. only
+     * enabled if "receiving" and "distributing" checkboxes
+     * are BOTH unchecked.
+     */
+    document.getElementById("filter-both").disabled = true
   }
 
   update() {
@@ -27,9 +29,11 @@ class Filter {
      */
     if (filterValues[0] === true || filterValues[1] === true) {
       filterValues[2] = true
+      document.getElementById("filter-both").checked = true
+      document.getElementById("filter-both").disabled = true
     }
-    if (!filterValues[0] && !filterValues[1]) {
-      filterValues[2] = false
+    else {
+      document.getElementById("filter-both").disabled = false
     }
 
     this.toggleMapPoints(filterValues);


### PR DESCRIPTION
### What
"open for both" checkbox behavior:
* if "receiving" and/or "distributing" is checked,  "open for both" is automatically checked but disabled (you cannot uncheck it)
* if "receiving" AND "distributing" are UNchecked, "open for both" is checked and enabled (you can uncheck it)

### Why
Addressing bug @comeoneileen found yesterday in the simplest way possible. Simpler solution to the issue than #50 . 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
