### PR TITLE
Update "See the data in Google Sheets" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     <button class='help-info-close-button' onClick="toggleHelpInfo(this)" aria-label="Close help info section">X Close</button>
     <p class='p txt-small'>Twin Cities Aid Map is run by volunteers.</p><br />
     <p class='p txt-small bold'>Have feedback? <a href="mailto:support@tcmap.org">Email Us</a>.</p>
-    <p class='p txt-small bold'>See this data in <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
+    <p class='p txt-small bold'>See this data in <a href="https://docs.google.com/spreadsheets/d/1CyPozeKhmOuIaVnKDQAUKKsvA9R4F20hEQ3MSGWczP8/edit?usp=sharing" target="_blank">Google Sheets</a>.</p>
     <p class='p txt-small bold'>Learn about this project on <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
   </div>
   <div class='map' id="map"></div>


### PR DESCRIPTION
Minor change to update the google sheets link from the "published for the web" version to a read-only shared version. This addresses issue https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/issues/62

My big worry here is that the owners of the spreadsheet are going to start getting flooded with requests to edit the document, which I don't think we can avoid while also making filtering the data possible -- the way to hide the "View only" callout would be to publish the spreadsheet for the web, which is exactly what we're doing now.