### PR TITLE
Uncheck unknown and closed sites on page load to make a clearer call to action

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -2,7 +2,7 @@
  * Filter adds a filter control to the side panel location list
  */
 class Filter {
-  
+
   constructor(el, options) {
     Object.assign(this, options)
     this.$filters = []
@@ -18,6 +18,11 @@ class Filter {
      * are BOTH unchecked.
      */
     document.getElementById("filter-both").disabled = true
+
+    // Uncheck closed and unknown status locations to make a clearer call to action for new users on the site.
+    document.getElementById("filter-closed").checked = false
+    document.getElementById("filter-unknown").checked = false
+    this.update()
   }
 
   update() {
@@ -38,7 +43,7 @@ class Filter {
 
     this.toggleMapPoints(filterValues);
     this.list.filter(i => {
-        const index = _.findIndex(this.statusOptions, o => { 
+        const index = _.findIndex(this.statusOptions, o => {
           return o.id === i.values().status;
         });
         return filterValues[index]
@@ -58,7 +63,7 @@ class Filter {
   }
 
   renderControls() {
-    
+
     const options = this.sortOptions.map(o => {
       return `<option value="${o.name}" ${o.selected && 'selected'}>${o.label}</option>`
     }).join('')
@@ -69,7 +74,7 @@ class Filter {
     }).join('')
 
     this.$controls.innerHTML = `
-      <div class="select-container">  
+      <div class="select-container">
         <label for="sort-by">Sort by: </label>
         <select name="sort-by" id="sort-by">
           ${options}


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.
-->

### What
Uncheck the `unknown` and `closed` filter checkboxes on page load.

### Why
So the initial page load has less going on, and the call to action is clearer.

I haven't talked to anyone else about this, I just thought I'd throw up a PR and see if you liked it. 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

### Screenshot on initial page load
![Screen Shot 2020-06-04 at 4 36 10 PM](https://user-images.githubusercontent.com/852709/83813015-28482f00-a682-11ea-9e10-ed84f9b6e16f.png)

Filters still work, you can still add back other sites when you click the checkbox. 
![Screen Shot 2020-06-04 at 4 44 08 PM](https://user-images.githubusercontent.com/852709/83813340-c2a87280-a682-11ea-96d9-4e980f0d54ec.png)