### PR TITLE
Move up last updated, add momentjs, use momentjs to do "n hours ago" sentence

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.5.1/mapbox-gl-geocoder.min.js"></script>
   <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.5.1/mapbox-gl-geocoder.css" type="text/css" />
   <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.26.0/moment.min.js"></script>
 
 	<!-- CONFIG -->
 	<script>

--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ map.addControl(
   }), 'bottom-right'
 )
 
-// Add zoom and rotate controls 
+// Add zoom and rotate controls
 map.addControl(new mapboxgl.NavigationControl(), 'bottom-right');
 
 // convert case
@@ -180,6 +180,7 @@ const onMapLoad = async () => {
           name: item.gsx$nameoforganization.$t,
           neighborhood: item.gsx$neighborhood.$t,
           address: item.gsx$addresswithlink.$t,
+          mostRecentlyUpdatedAt: item.gsx$mostrecentlyupdated.$t,
           currentlyOpenForDistributing: item.gsx$currentlyopenfordistributing.$t,
           openingForDistributingDontations: item.gsx$openingfordistributingdonations.$t,
           closingForDistributingDonations: item.gsx$closingfordistributingdonations.$t,
@@ -191,8 +192,7 @@ const onMapLoad = async () => {
           seekingVolunteers: item.gsx$seekingvolunteers.$t,
           seekingMoney: seekingMoney,
           urgentNeed: item.gsx$urgentneed.$t,
-          notes: item.gsx$notes.$t,
-          mostRecentlyUpdatedAt: item.gsx$mostrecentlyupdated.$t
+          notes: item.gsx$notes.$t
         }
         const location = _.pickBy(rawLocation, val => val != '')
         const status = getStatus(item.gsx$color.$t)
@@ -205,7 +205,8 @@ const onMapLoad = async () => {
         const propertyTransforms = {
           name: (name) => `<h2 class='h2'>${name}</h2>`,
           neighborhood: (neighborhood) => `<h3 class='h3'>${neighborhood}</h3>`,
-          address: (address) => `<address><a href="https://maps.google.com?saddr=Current+Location&daddr=${encodeURI(address)}" target="_blank">${address}</a></address>` // driving directions in google, consider doing inside mapbox
+          address: (address) => `<address><a href="https://maps.google.com?saddr=Current+Location&daddr=${encodeURI(address)}" target="_blank">${address}</a></address>`, // driving directions in google, consider doing inside mapbox
+          mostRecentlyUpdatedAt: (datetime) => `<div class='p row'><p class='txt-deemphasize key'>Last Updated</p><p class='value' title='${datetime}'>${moment(datetime, 'H:m M/D').fromNow()}</p></div>`
         }
 
         // render HTML for marker

--- a/script.js
+++ b/script.js
@@ -6,7 +6,14 @@ const $body = document.body;
 
 // we're using the map color from google sheet to indicate location status,
 // but using a different display color for accessibility. so the original
-// color is treated ad an ID
+// color is treated as an ID
+const unknownStatus =   {
+  id: '#aaaaaa',
+  name: 'unknown',
+  label: 'status unknown',
+  accessibleColor: '#ffffbf'
+}
+
 const statusOptions = [
   {
     id: '#fc03df',
@@ -32,12 +39,7 @@ const statusOptions = [
     label: 'currently closed',
     accessibleColor: '#d7191c'
   },
-  {
-    id: '#aaaaaa',
-    name: 'unknown',
-    label: 'status unknown',
-    accessibleColor: '#ffffbf'
-  }
+  unknownStatus
 ]
 
 let locations = []
@@ -115,8 +117,11 @@ function closePopups() {
   })
 }
 
-// get the status info for a location using the color as ID
-const getStatus = id => _.find(statusOptions, s => (s.id === id.toLowerCase()))
+// get the status info for a location using the color as ID, else default to unknown.
+const getStatus = id => {
+  const status = _.find(statusOptions, s => (s.id === id.toLowerCase()))
+  return status || unknownStatus
+}
 
 // create an item for the side pane using a location
 const createListItem = (location, status, lng, lat) => {
@@ -196,10 +201,6 @@ const onMapLoad = async () => {
         }
         const location = _.pickBy(rawLocation, val => val != '')
         const status = getStatus(item.gsx$color.$t)
-
-        if (!status) {
-          throw new Error("Malformed data for " + location.name + ", could not find status: " + item.gsx$color.$t)
-        }
 
         // transform location properties into HTML
         const propertyTransforms = {

--- a/script.js
+++ b/script.js
@@ -207,7 +207,7 @@ const onMapLoad = async () => {
           name: (name) => `<h2 class='h2'>${name}</h2>`,
           neighborhood: (neighborhood) => `<h3 class='h3'>${neighborhood}</h3>`,
           address: (address) => `<address><a href="https://maps.google.com?saddr=Current+Location&daddr=${encodeURI(address)}" target="_blank">${address}</a></address>`, // driving directions in google, consider doing inside mapbox
-          mostRecentlyUpdatedAt: (datetime) => `<div class='p row'><p class='txt-deemphasize key'>Last Updated</p><p class='value' title='${datetime}'>${moment(datetime, 'H:m M/D').fromNow()}</p></div>`
+          mostRecentlyUpdatedAt: (datetime) => `<div class='updated-at' title='${datetime}'>Last updated ${moment(datetime, 'H:m M/D').fromNow()}</div>`
         }
 
         // render HTML for marker

--- a/styles.css
+++ b/styles.css
@@ -289,6 +289,7 @@ input[type='checkbox'] + label {
 
 .popup-content address {
   padding-bottom: 5px;
+  font-style: normal;
 }
 
 .popup-content .updated-at {

--- a/styles.css
+++ b/styles.css
@@ -288,7 +288,12 @@ input[type='checkbox'] + label {
 }
 
 .popup-content address {
+  padding-bottom: 5px;
+}
+
+.popup-content .updated-at {
   padding-bottom: 20px;
+  font-style: italic;
 }
 
 /* component: traffic counter */


### PR DESCRIPTION
### What
Moves up last updated on the map pins and uses `moment.js` to parse the date and spit out a nice string like `8 hours ago` or `2 days ago`. Display the unparsed date string as the `title` so desktop users can hover on it to get a more refined display. If we need something better for mobile users that can be done too (not sure what yet...).

I'm also not sure if you guys are down with adding another JS lib in the global namespace. Feel free to call that out. IMO the momentjs stuff isn't necessary to make this more prominent just kind of fun to have. 

### Why
Resolves https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/issues/75

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

### Screenshots

![Screen Shot 2020-06-04 at 10 56 52 PM](https://user-images.githubusercontent.com/852709/83835739-38c6cc80-a6b7-11ea-8b6f-f3c6832f8886.png)
![Screen Shot 2020-06-04 at 10 56 41 PM](https://user-images.githubusercontent.com/852709/83835743-39f7f980-a6b7-11ea-8f5d-d33a6b67c8ea.png)

