### PR TITLE
Change support email temporarily while MX records refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
   <div id="help-info" class='help-info padded spaced-lines'>
     <button class='help-info-close-button' onClick="toggleHelpInfo(this)" aria-label="Close help info section">X Close</button>
     <p class='p txt-small'>Twin Cities Aid Map is run by volunteers.</p><br />
-    <p class='p txt-small bold'>Have feedback? <a href="mailto:support@tcmap.org">Email Us</a>.</p>
+    <p class='p txt-small bold'>Have feedback? <a href="mailto:tcmap@michellefunk.com">Email Us</a>.</p>
     <p class='p txt-small bold'>See this data in <a href="https://docs.google.com/spreadsheets/d/1CyPozeKhmOuIaVnKDQAUKKsvA9R4F20hEQ3MSGWczP8/edit?usp=sharing" target="_blank">Google Sheets</a>.</p>
     <p class='p txt-small bold'>Learn about this project on <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
   </div>


### PR DESCRIPTION
### What
We've moved over to Wordpress hosting for tcmap.org which has temporarily broken the support@ email. This should be resolving in the next few hours, hopefully sooner rather than later. We will revert this once it is working again.

The reason I used my personal domain is because the last time we tried to create a mutual aid gmail account it was flagged by google and suspended. 

### Why
support@tcmap.org is temporarily broken.

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [ ] Tapping on a marker on the map displays information about the marker in a popup.
- [ ] Tapping the "Show list of locations" button replaces the map view with a list view.
- [ ] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [ ] Tapping one of the ✅'s in the legend filters items on the map and in the list.

### Check the app in the following web browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
