### PR TITLE
Adds count to statusOptions

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -70,7 +70,7 @@ class Filter {
 
 
     const filters = this.statusOptions.map(s => {
-      return `<li class='filter-item'><input class="filter" type="checkbox" id="filter-${s.name}" value="${s.name}" checked><span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span><label for="filter-${s.name}">${s.label}</label></li>`
+      return `<li class='filter-item'><input class="filter" type="checkbox" id="filter-${s.name}" value="${s.name}" checked><span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span><label for="filter-${s.name}">${s.label} (${s.count})</label></li>`
     }).join('')
 
     this.$controls.innerHTML = `

--- a/script.js
+++ b/script.js
@@ -42,7 +42,7 @@ const statusOptions = [
     label: 'status unknown',
     accessibleColor: '#ffffbf',
     count: 0
-  },
+  }
 ]
 
 let locations = []

--- a/script.js
+++ b/script.js
@@ -12,32 +12,37 @@ const statusOptions = [
     id: '#fc03df',
     name: 'recieving',
     label: 'open for receiving donations',
-    accessibleColor: '#2c7bb6'
+    accessibleColor: '#2c7bb6',
+    count: 0
   },
   {
     id: '#03bafc',
     name: 'distributing',
     label: 'open for distributing donations',
-    accessibleColor: '#abd9e9'
+    accessibleColor: '#abd9e9',
+    count: 0
   },
   {
     id: '#9f48ea',
     name: 'both',
     label: 'open for both',
-    accessibleColor: '#fdae61'
+    accessibleColor: '#fdae61',
+    count: 0
   },
   {
     id: '#c70000',
     name: 'closed',
     label: 'currently closed',
-    accessibleColor: '#d7191c'
+    accessibleColor: '#d7191c',
+    count: 0
   },
   {
     id: '#aaaaaa',
     name: 'unknown',
     label: 'status unknown',
-    accessibleColor: '#ffffbf'
-  }
+    accessibleColor: '#ffffbf',
+    count: 0
+  },
 ]
 
 let locations = []
@@ -126,6 +131,11 @@ const createListItem = (location, status, lng, lat) => {
   const $item = document.createElement('div')
   $item.classList.add('location-list--item')
   $item.dataset.id = status.id;
+
+  // Increments number of total 
+  // locations that fit this status.
+  status.count++ 
+
   $item.innerHTML = `
     <div class="flex">
       <span title="${status.id}" class="status location-list--indicator" style="background-color: ${status.accessibleColor};">${status.id}</span>


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.
-->

### What
This adds the count of each of the statusOptions available, as per issue #80

### Why
_What problem does this pull requests solve?  Reference related issues if appropriate._

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [ ] Tapping the "Show list of locations" button replaces the map view with a list view.
**I don't see this button in production**

- [ ] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
**I don't see this button in production**

- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [] Changing the language to spanish changes things on the page.
**This is a more recent change that my fork doesn't have, but I didn't change anything to do with this.** 

- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari
