### PR TITLE
Link to "Public Html" Version of the Sheet

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,7 +53,7 @@
     <button id='help-info-close-button' class='help-info-close-button' aria-label="Close help info section">X <span data-translation-id="close">Close</span></button>
     <p class='p txt-small'><span data-translation-id="project_description">Twin Cities Aid Map is run by volunteers</span>.</p><br />
     <p class='p txt-small bold'><span data-translation-id="project_feedback">Have feedback?</span> <a href="mailto:support@tcmap.org" data-translation-id="project_contact">Email Us</a>.</p>
-    <p class='p txt-small bold'><span data-translation-id="project_data">See this data in</span> <a href="https://docs.google.com/spreadsheets/d/1CyPozeKhmOuIaVnKDQAUKKsvA9R4F20hEQ3MSGWczP8/edit?usp=sharing" target="_blank">Google Sheets</a>.</p>
+    <p class='p txt-small bold'><span data-translation-id="project_data">See this data in</span> <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
     <p class='p txt-small bold'><span data-translation-id="project_learn">Learn about this project on</span> <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
   </div>
   <div class='map' id="map">


### PR DESCRIPTION
### What
This change reverts the link to the Google Sheet back to Publish to Html version.

### Why
The readonly (rather than then publish to web version) leaks information that we wish to remain private.

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [ ] Tapping on a marker on the map displays information about the marker in a popup.
- [ ] Tapping the "Show list of locations" button replaces the map view with a list view.
- [ ] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [ ] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [ ] Changing the language to spanish changes things on the page.
- [ ] Clicking the Help/Info button opens and closes a menu with information.
- [ ] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
