### PR TITLE
Add line from #113 incorporating TCMAP website

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
   </div>
   <div id="help-info" class='help-info padded spaced-lines'>
     <button id='help-info-close-button' class='help-info-close-button' aria-label="Close help info section">X <span data-translation-id="close">Close</span></button>
-    <p class='p txt-small'><span data-translation-id="project_description">Twin Cities Mutual Aid Map is ran by volunteers as part of the <a href="http://tcmap.org">Twin Cities Mutual Aid Project</a></span>.</p><br />
+    <p class='p txt-small'><span data-translation-id="project_description">Twin Cities Mutual Aid Map is run by volunteers as part of the <a href="http://tcmap.org">Twin Cities Mutual Aid Project</a></span>.</p><br />
     <p class='p txt-small bold'><span data-translation-id="project_feedback">Have feedback?</span> <a href="mailto:support@tcmap.org" data-translation-id="project_contact">Email Us</a>.</p>
     <p class='p txt-small bold'><span data-translation-id="project_data">See this data in</span> <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
     <p class='p txt-small bold'><span data-translation-id="project_learn">Learn about this project on</span> <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>

--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
   </div>
   <div id="help-info" class='help-info padded spaced-lines'>
     <button id='help-info-close-button' class='help-info-close-button' aria-label="Close help info section">X <span data-translation-id="close">Close</span></button>
-    <p class='p txt-small'><span data-translation-id="project_description">Twin Cities Aid Map is run by volunteers</span>.</p><br />
+    <p class='p txt-small'><span data-translation-id="project_description">Twin Cities Mutual Aid Map is ran by volunteers as part of the <a href="http://tcmap.org">Twin Cities Mutual Aid Project</a></span>.</p><br />
     <p class='p txt-small bold'><span data-translation-id="project_feedback">Have feedback?</span> <a href="mailto:support@tcmap.org" data-translation-id="project_contact">Email Us</a>.</p>
     <p class='p txt-small bold'><span data-translation-id="project_data">See this data in</span> <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
     <p class='p txt-small bold'><span data-translation-id="project_learn">Learn about this project on</span> <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.
-->

### What
Restores the line from #113 in the help text to link to TCMAP, but with fixes to typos. 

### Why
We had no link to tcmap :) 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [ ] Tapping on a marker on the map displays information about the marker in a popup.
- [ ] Tapping the "Show list of locations" button replaces the map view with a list view.
- [ ] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [ ] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [ ] Changing the language to spanish changes things on the page.
- [ ] Clicking the Help/Info button opens and closes a menu with information.
- [ ] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
