### PR TITLE
:bug: #123 make language selection modal scrollable

### DIFF
--- a/src/styles/welcome.css
+++ b/src/styles/welcome.css
@@ -26,6 +26,8 @@
   padding: 20px;
   background-color: #fff;
   text-align: center;
+  max-height: 100%;
+  overflow-y: scroll;
 }
 
 .modal-languages {


### PR DESCRIPTION
### What
Makes language selection modal scrollable

### Why
The number of languages causes issues on smaller screen sizes. See issue #123 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari
