### PR TITLE
Issue #121

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -151,9 +151,11 @@ function truthy(str) {
 function toggleSidePane() {
   if ($body.classList.contains('list-active')) {
     $locationsButton.innerText = translator.get('show_list_button', 'Show list of locations')
+    $locationsButton.setAttribute('data-translation-id', 'show_list_button')
     $body.classList.remove('list-active')
   } else {
     $locationsButton.innerText = translator.get('hide_list_button', 'Hide list of locations')
+    $locationsButton.setAttribute('data-translation-id', 'hide_list_button')
     $body.classList.add('list-active')
   }
 }


### PR DESCRIPTION
### What
Minor change to switch the translation-id for show/hide list button depending on its state

### Why
#121 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari
