### PR TITLE
adding range to hours

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -308,7 +308,7 @@ function extractRawLocation(item) {
     accepting: item.gsx$accepting.$t,
     notAccepting: item.gsx$notaccepting.$t,
     currentlyOpenForReceiving: item.gsx$currentlyopenforreceiving.$t,
-    receivingHours: getHours(item.gsx$openingforreceivingdonations.$t, item.gsx$closingforreceivingdonations.$t),
+    aidReceivingHours: getHours(item.gsx$openingforreceivingdonations.$t, item.gsx$closingforreceivingdonations.$t),
     seekingVolunteers: item.gsx$seekingvolunteers.$t,
     urgentNeed: item.gsx$urgentneed.$t,
     notes: item.gsx$notes.$t

--- a/src/index.js
+++ b/src/index.js
@@ -304,7 +304,7 @@ function extractRawLocation(item) {
     seekingMoney: extractSeekingMoney(item),
     seekingMoneyURL: extractSeekingMoneyURL(item),
     currentlyOpenForDistributing: item.gsx$currentlyopenfordistributing.$t,
-    distributionHours: getHours(item.gsx$openingfordistributingdonations.$t, item.gsx$closingfordistributingdonations.$t),
+    aidDistributionHours: getHours(item.gsx$openingfordistributingdonations.$t, item.gsx$closingfordistributingdonations.$t),
     accepting: item.gsx$accepting.$t,
     notAccepting: item.gsx$notaccepting.$t,
     currentlyOpenForReceiving: item.gsx$currentlyopenforreceiving.$t,

--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ function extractSeekingMoneyURL(item) {
 ///////////
 // returns a range of hours if opening or closing is provided
 // e.g. "7:00 AM to 5:00 PM"
-// else returns just the opening hours texy
+// else returns just the opening hours text
 // e.g "not today", or "never"
 ///////////
 function getHours(openingHours, closingHours) {

--- a/src/index.js
+++ b/src/index.js
@@ -281,6 +281,20 @@ function extractSeekingMoneyURL(item) {
 }
 //////////////////////////
 
+///////////
+// returns a range of hours if opening or closing is provided
+// e.g. "7:00 AM to 5:00 PM"
+// else returns just the opening hours texy
+// e.g "not today", or "never"
+///////////
+function getHours(openingHours, closingHours) {
+  if (openingHours && closingHours) {
+    return openingHours + ' to ' + closingHours
+  } else {
+    return openingHours
+  }
+}
+
 function extractRawLocation(item) {
   return {
     name: item.gsx$nameoforganization.$t,
@@ -290,13 +304,11 @@ function extractRawLocation(item) {
     seekingMoney: extractSeekingMoney(item),
     seekingMoneyURL: extractSeekingMoneyURL(item),
     currentlyOpenForDistributing: item.gsx$currentlyopenfordistributing.$t,
-    openingForDistributingDontations: item.gsx$openingfordistributingdonations.$t,
-    closingForDistributingDonations: item.gsx$closingfordistributingdonations.$t,
+    distributionHours: getHours(item.gsx$openingfordistributingdonations.$t, item.gsx$closingfordistributingdonations.$t),
     accepting: item.gsx$accepting.$t,
     notAccepting: item.gsx$notaccepting.$t,
     currentlyOpenForReceiving: item.gsx$currentlyopenforreceiving.$t,
-    openingForReceivingDontations: item.gsx$openingforreceivingdonations.$t,
-    closingForReceivingDonations: item.gsx$closingforreceivingdonations.$t,
+    receivingHours: getHours(item.gsx$openingforreceivingdonations.$t, item.gsx$closingforreceivingdonations.$t),
     seekingVolunteers: item.gsx$seekingvolunteers.$t,
     urgentNeed: item.gsx$urgentneed.$t,
     notes: item.gsx$notes.$t


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.
-->

### What
Creates an hour range for the distribution and receiving hours, brought up in #122. Will need to add the new keys `distribution_hours` and `receiving_hours` to the translation spreadsheet for translation to work properly.

##### location with hours
<img width="273" alt="Screen Shot 2020-06-06 at 4 11 12 PM" src="https://user-images.githubusercontent.com/11835669/83954941-42fddd80-a813-11ea-998f-d1c7aaa158d2.png">

##### location without hours
<img width="288" alt="Screen Shot 2020-06-06 at 4 10 47 PM" src="https://user-images.githubusercontent.com/11835669/83954952-67f25080-a813-11ea-8621-8982bf021b69.png">

### Why
Having the hours on separate lines took up lots of space and was not as easy to read.

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [ ] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge 😬 
- [x] Safari
