### PR TITLE
Adds count to map key, closes issue #80

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,8 @@ const unknownStatus =   {
   id: '#aaaaaa',
   name: 'unknown',
   label: 'status unknown',
-  accessibleColor: '#ffffbf'
+  accessibleColor: '#ffffbf',
+  count: 0
 }
 
 const statusOptions = [
@@ -46,25 +47,29 @@ const statusOptions = [
     id: '#fc03df',
     name: 'recieving',
     label: 'open for receiving donations',
-    accessibleColor: '#2c7bb6'
+    accessibleColor: '#2c7bb6',
+    count: 0
   },
   {
     id: '#03bafc',
     name: 'distributing',
     label: 'open for distributing donations',
-    accessibleColor: '#abd9e9'
+    accessibleColor: '#abd9e9',
+    count: 0
   },
   {
     id: '#9f48ea',
     name: 'both',
     label: 'open for both',
-    accessibleColor: '#fdae61'
+    accessibleColor: '#fdae61',
+    count: 0
   },
   {
     id: '#c70000',
     name: 'closed',
     label: 'currently closed',
-    accessibleColor: '#d7191c'
+    accessibleColor: '#d7191c',
+    count: 0
   },
   unknownStatus
 ]
@@ -223,6 +228,11 @@ const createListItem = (location, status, lng, lat) => {
   const $item = document.createElement('div')
   $item.classList.add('location-list--item')
   $item.dataset.id = status.id;
+
+  // Increments the total count 
+  // for this status. 
+  status.count++
+
   $item.innerHTML = `
     <div class="flex">
       <span title="${status.id}" class="status location-list--indicator" style="background-color: ${status.accessibleColor};">${status.id}</span>

--- a/src/js/filter.js
+++ b/src/js/filter.js
@@ -74,7 +74,7 @@ class Filter {
 
 
     const filters = this.statusOptions.map(s => {
-      return `<li class='filter-item'><input class="filter" type="checkbox" id="filter-${s.name}" value="${s.name}" checked><span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span><label data-translation-id="filter_by_${_.snakeCase(s.name)}" for="filter-${s.name}">${s.label}</label></li>`
+      return `<li class='filter-item'><input class="filter" type="checkbox" id="filter-${s.name}" value="${s.name}" checked><span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span><label data-translation-id="filter_by_${_.snakeCase(s.name)}" for="filter-${s.name}">${s.label}</label><label> (${s.count})</label></li>`
     }).join('')
 
     this.$controls.innerHTML = `


### PR DESCRIPTION
### What
This adds the count of each of the statusOptions available, as per issue #80

### Why
This aids in less confusion during nighttime hours when the map is empty -- it's more obvious that there are locations that are hidden. 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari

Also note that mobile view was checked as well, and no weird wrapping issues seem to occur. 