### PR TITLE
Translation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ extract the sheet ID out of the url to plug into the DATA_URL const.
   const DATA_URL = 'https://spreadsheets.google.com/feeds/list/1XJhbzcT_AubgnqAJRsbOEbMO3HPTybG3yNcX6i-BgH0/1/public/full?alt=json'
 `
 
+## Additional documentation
+
+ * Information about adding, editing and maintaining languages can be found in [Language Translation](docs/LANGUAGE_TRANSLATION.md)
+
+
 ## About the application
 This started as a very lightweight, single page html file, and we've tried very hard to keep things as simple as possible.
 

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -30,7 +30,7 @@ A basic reference for what kind of access is needed for various actions in the t
 | Adding a Language | Yes | Yes | 
 | Enabling a Language | No | Yes |
 
-* assuming the translator is working outside the main spreadsheet
+*assuming the translator is working outside the main spreadsheet
 
 ### The translation spreadsheet
 

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -2,6 +2,8 @@
 
 > **Note:** development on this project is moving quickly, so parts of this document may be out of date. Feel free to ask questions in the `#tc-aid-translations` channel in Slack.
 
+<!-- TOC -->autoauto- [Language Translation](#language-translation)auto  - [Overview](#overview)auto    - [The translation spreadsheet](#the-translation-spreadsheet)auto    - [Glossary](#glossary)auto    - [Special links](#special-links)auto  - [Maintaining Translations](#maintaining-translations)auto    - [Translating existing terms](#translating-existing-terms)auto    - [Creating a new term](#creating-a-new-term)auto    - [Adding a new language](#adding-a-new-language)auto      - [Adding a column to the spreadsheet](#adding-a-column-to-the-spreadsheet)auto      - [Adding a new flag image](#adding-a-new-flag-image)auto      - [Enabling the language](#enabling-the-language)auto  - [Technical Details](#technical-details)auto    - [`language`](#language)auto    - [`translate([<Element>])`](#translateelement)autoauto<!-- /TOC -->
+
 ## Overview
 
 The site translations work by loading a spreadsheet of translated terms, and replacing the hard-coded English terms on the page with the translated ones. If a translated term is missing in the spreadsheet, the English term will be used. The terms that need to be translated are specified **in the code**, it will **not** automatically find words on the page. 

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -28,12 +28,21 @@ Here's the basic format of the spreadsheet:
 
 The first column (e.g. `lang_name`) and first row (e.g. `eng`) are *required* and must be filled out for any added row/column. The rest of the fields can be filled up as new translated terms are available.
 
-Glossary
+### Glossary
 
  * **Languages:** Pretty self-explanatory (a column in the spreadsheet)
  * **Terms:** A word or set of words that need to be translated (a row in the spreadsheet). The term is identified by the `id` column
  * **Translated Terms:** An individual translated term (a cell in the spreadsheet)
 
+### Special links
+
+If you want to link to a specific language (like if you're sending the link to somebody you know speaks Somali) you can add `?lang=XXX` to the end of the URL. Example: 
+
+https://twin-cities-mutual-aid.org/?lang=som
+
+If you want to preview languages that have been created but not enabled, add `?dev to the end of the url:
+
+https://twin-cities-mutual-aid.org/?dev
 
 ## Maintaining Translations
 
@@ -72,7 +81,13 @@ if (window.location.search.indexOf('dev') > -1) {
 }
 ```
 
+Note that there are **two** sets of language codes, one for preview mode and one for the live site.
+
+A checklist for enabling a language:
+
+ - [ ] 3-letter code is added to both arrays (one for production, one for development)
 
 
 ## Technical Details
 
+Keep in mind that development is moving very fast on this project, so this may become outdated pretty quickly.

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -2,6 +2,22 @@
 
 ## Overview
 
+The site translations work by loading a spreadsheet of translated terms, and replacing (English) words on the page with the translated ones. The words that need to be translated are specified **in the code**, it will **not** automatically find words on the page. 
+
+A basic reference for what kind of access is needed for various actions in the translation process. 
+
+| Action | Edit Spreadsheet | Update to code |
+| :-----------------| :-: | :-: |
+| Translating terms | No | No |
+| Adding translated terms | Yes | No |
+| Adding new terms | Yes | Yes | 
+| Adding a Language | Yes | Yes | 
+| Enabling a Language | No | Yes |
+
+
+The spreadsheet used for defining translations is here: https://docs.google.com/spreadsheets/d/1m5QPNP6O8nsQsqJcQbwib_obpXRjmbYYGtwKzzg1l38/edit?pli=1#gid=0. You can request access in the slack channel `#tc-aid-translations`.
+
+Here's the basic format of the spreadsheet:
 
 | id | eng | spa | 
 | :--------- | :-------- |:--------- |
@@ -10,12 +26,14 @@
 | language | Language | Idioma |
 | welcome | Welcome! | ¡Bienvenidos! |
 
- - **Column names are required**
- - **Column names should be a 3-letter code**, [ideally from this standard](https://en.wikipedia.org/wiki/ISO_639-2).
+The first column (e.g. `lang_name`) and first row (e.g. `eng`) are *required* and must be filled out for any added row/column. The rest of the fields can be filled up as new translated terms are available.
 
-```html
-<span data-translation-id="needs_money">Needs Money</span>
-```
+Glossary
+
+ * **Languages:** Pretty self-explanatory (a column in the spreadsheet)
+ * **Terms:** A word or set of words that need to be translated (a row in the spreadsheet). The term is identified by the `id` column
+ * **Translated Terms:** An individual translated term (a cell in the spreadsheet)
+
 
 ## Maintaining Translations
 
@@ -29,7 +47,7 @@
 
 A checklist for adding a new column to the checklist
 
- - [ ] The language header should contain a 3-letter code like `som` (a list of these can be [found here](https://en.wikipedia.org/wiki/ISO_639-2))
+ - [ ] The language header should contain a 3-letter code like `som` (a list of these can be [found here](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes)) 
 
 #### Adding a new flag image
 
@@ -42,5 +60,19 @@ A checklist for adding new flag images
 
 #### Enabling the language
 
+Languages are currently enabled via a hard-coded list of enabled languages. At time of writing the languages are defined in code like this:
 
-## Technical Detials
+```js
+// show all langs in dev mode
+if (window.location.search.indexOf('dev') > -1) {
+  langs = ['eng', 'spa', 'kar', 'som', 'hmn', 'amh', 'orm', 'vie']
+// otherwise only show these
+} else {
+  langs = ['eng', 'spa', 'som', 'amh', 'orm', 'vie']
+}
+```
+
+
+
+## Technical Details
+

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -2,6 +2,20 @@
 
 > **Note:** development on this project is moving quickly, so parts of this document may be out of date. Feel free to ask questions in the `#tc-aid-translations` channel in Slack.
 
+1. Overview
+   1. The translation spreadsheet
+   2. Glossary
+   3. Special links
+2. Maintaining translations
+   1. Translating existing terms
+   2. Creating a new term
+   3. Adding a new language
+3. Technical details
+   1. Adding a term in markup (`data-translation-id`)
+   2. Getting a translated term in js code (`get`)
+   3. Setting the current language (`language`)
+   4. Running translation substitution (`translate`)
+
 ## Overview
 
 The site translations work by loading a spreadsheet of translated terms, and replacing the hard-coded English terms on the page with the translated ones. If a translated term is missing in the spreadsheet, the English term will be used. The terms that need to be translated are specified **in the code**, it will **not** automatically find words on the page. 
@@ -123,7 +137,7 @@ Some quick notes:
  * The main code for this feature is in `/src/js/translator.js`
  * We are using [`ISO 639-2`](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) (3-letter) codes instead of the more common `ISO 639-1` (2-letter) because the former has broader langauge support (for instance: Karen Languages).
 
- ### Adding a term in markup
+ ### Adding a term in markup (`data-translation-id`)
 
  Terms are added in the markup using the `data-translation-id` data attribute. For instance:
 
@@ -131,20 +145,25 @@ Some quick notes:
  <span data-translation-id="term_name">Default text</span>
  ```
 
- ### `get(<string>, [<string>])`
+ ### Getting a translated term in js code (`get`)
 
  This is the method for fetching a translation in js code:
 
- ```js
-const translatedTerm = translator.get('term_name', 'Default text')
- ```
+`get(<string>, [<string>])`
 
 Arguments
 
 1. The name of the term from the `id` column in the spreadsheet
 2. A default string to use if the translated term isn't found
 
-### `language`
+Example:
+
+
+ ```js
+const translatedTerm = translator.get('term_name', 'Default text')
+ ```
+
+### Setting the current language (`language`)
 
 The current language is set and retrieved using the `language` getter/setter:
 
@@ -153,7 +172,9 @@ translator.language = 'vie'
 const currentLanguage = translator.language
 ```
 
-### `translate([<Element>])`
+### Running translation substitution (`translate`)
+
+`translate([<Element>])`
 
 This will perform translation substitution on the given DOM `Element`. If no `Element` is given, `document` will be used.
 

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -1,5 +1,7 @@
 # Language Translation
 
+> **Note:** development on this project is moving quickly, so parts of this document may be out of date. Feel free to ask questions in the `#tc-aid-translations` channel in Slack.
+
 ## Overview
 
 The site translations work by loading a spreadsheet of translated terms, and replacing the hard-coded English terms on the page with the translated ones. If a translated term is missing in the spreadsheet, the English term will be used. The terms that need to be translated are specified **in the code**, it will **not** automatically find words on the page. 
@@ -27,7 +29,7 @@ Here's the basic format of the spreadsheet:
 | language | Language | Idioma |
 | welcome | Welcome! | ¡Bienvenidos! |
 
-The first column (e.g. `lang_name`) and first row (e.g. `eng`) are *required* and must be filled out for any added row/column. The rest of the fields can be filled up as new translated terms are available.
+The first column (e.g. `lang_name`) and first row (e.g. `eng`) are **required** and must be filled out for any added row/column. The rest of the cells can be filled in as new translated terms are available.
 
 ### Glossary
 
@@ -37,7 +39,7 @@ The first column (e.g. `lang_name`) and first row (e.g. `eng`) are *required* an
 
 ### Special links
 
-If you want to link to a specific language (like if you're sending the link to somebody you know speaks Somali) you can add `?lang=XXX` to the end of the URL. Example: 
+If you want to link to a specific language (say you're sending the link to somebody you know speaks Somali) you can add `?lang=XXX` to the end of the URL. Example: 
 
 https://twin-cities-mutual-aid.org/?lang=som
 
@@ -59,7 +61,7 @@ Checklist:
 
  - [ ] Create a new row in the spreadsheet for the new term
  - [ ] Make sure that there is a **unique** name in the `id` column, `formatted_like_this`
- - [ ] Make sure the term is also added to the correct place in the code, using either the `data-translation-id` attribute or the `translator.get('term_name')` method (see technical details below).
+ - [ ] Make sure the term is also added to the correct place in the code, using either the `data-translation-id` attribute (in markup) or the `get` method (js code). See technical details below for more on this.
 
 ### Adding a new language
 
@@ -78,6 +80,10 @@ A checklist for adding a new column to the checklist
  - [ ] The language header should contain a 3-letter code like `som` (a list of these can be [found here](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes)) 
 
 #### Adding a new flag image
+
+A good resource for hard-to-find flag images:
+
+https://en.wikipedia.org/wiki/Unrepresented_Nations_and_Peoples_Organization#Members
 
 A checklist for adding new flag images
 
@@ -110,4 +116,46 @@ A checklist for enabling a language:
 
 ## Technical Details
 
-Keep in mind that development is moving very fast on this project, so this may become outdated pretty quickly.
+Some quick notes:
+
+ * The main code for this feature is in `/src/js/translator.js`
+ * We are using [`ISO 639-2`](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) (3-letter) codes instead of the more common `ISO 639-1` (2-letter) because the former has broader langauge support (for instance: Karen Languages).
+
+ ### Adding a term in markup
+
+ Terms are added in the markup using the `data-translation-id` data attribute. For instance:
+
+ ```html
+ <span data-translation-id="term_name">Default text</span>
+ ```
+
+ ### `get(<string>, [<string>])`
+
+ This is the method for fetching a translation in js code:
+
+ ```js
+const translatedTerm = translator.get('term_name', 'Default text')
+ ```
+
+Arguments
+
+1. The name of the term from the `id` column in the spreadsheet
+2. A default string to use if the translated term isn't found
+
+### `language`
+
+The current language is set and retrieved using the `language` getter/setter:
+
+```js
+translator.language = 'vie'
+const currentLanguage = translator.language
+```
+
+### `translate([<Element>])`
+
+This will perform translation substitution on the given DOM `Element`. If no `Element` is given, `document` will be used.
+
+```js
+document.body.innerHTML = '<span data-translation-id="term_name">Default text</span>'
+translator.translate()
+```

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -59,7 +59,7 @@ If you want to link to a specific language (say you're sending the link to someb
 
 https://twin-cities-mutual-aid.org/?lang=som
 
-If you want to preview languages that have been created but not enabled, add `?dev to the end of the url:
+If you want to preview languages that have been created but not enabled, add `?dev` to the end of the url:
 
 https://twin-cities-mutual-aid.org/?dev
 

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The site translations work by loading a spreadsheet of translated terms, and replacing (English) words on the page with the translated ones. The words that need to be translated are specified **in the code**, it will **not** automatically find words on the page. 
+The site translations work by loading a spreadsheet of translated terms, and replacing the hard-coded English terms on the page with the translated ones. If a translated term is missing in the spreadsheet, the English term will be used. The terms that need to be translated are specified **in the code**, it will **not** automatically find words on the page. 
 
 A basic reference for what kind of access is needed for various actions in the translation process. 
 
-| Action | Edit Spreadsheet | Update to code |
+| Action | Edit Spreadsheet | Update code |
 | :-----------------| :-: | :-: |
 | Translating terms | No | No |
 | Adding translated terms | Yes | No |
@@ -14,6 +14,7 @@ A basic reference for what kind of access is needed for various actions in the t
 | Adding a Language | Yes | Yes | 
 | Enabling a Language | No | Yes |
 
+### The translation spreadsheet
 
 The spreadsheet used for defining translations is here: https://docs.google.com/spreadsheets/d/1m5QPNP6O8nsQsqJcQbwib_obpXRjmbYYGtwKzzg1l38/edit?pli=1#gid=0. You can request access in the slack channel `#tc-aid-translations`.
 
@@ -48,9 +49,27 @@ https://twin-cities-mutual-aid.org/?dev
 
 ### Translating existing terms
 
+This is fairly straightforward, just add the term to the correct place in the spreadsheet :). Checklist:
+
+ - [ ] The translated term is added to the correct column/row of the spreadsheet
+
 ### Creating a new term
 
+Checklist:
+
+ - [ ] Create a new row in the spreadsheet for the new term
+ - [ ] Make sure that there is a **unique** name in the `id` column, `formatted_like_this`
+ - [ ] Make sure the term is also added to the correct place in the code, using either the `data-translation-id` attribute or the `translator.get('term_name')` method (see technical details below).
+
 ### Adding a new language
+
+Adding a language involves a few steps:
+
+| Action | Edit Spreadsheet | Update code |
+| :-----------------| :-: | :-: |
+| 1. Adding a column to the spreadsheet | Yes | No |
+| 2. Adding a new flag image | No | Yes |
+| 3. Enabling the language | No | Yes | 
 
 #### Adding a column to the spreadsheet
 
@@ -85,7 +104,8 @@ Note that there are **two** sets of language codes, one for preview mode and one
 
 A checklist for enabling a language:
 
- - [ ] 3-letter code is added to both arrays (one for production, one for development)
+ - [ ] 3-letter code is added to the array for dev/preview mode
+ - [ ] 3-letter code is added to the array for production mode
 
 
 ## Technical Details

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -144,6 +144,7 @@ Some quick notes:
  ```html
  <span data-translation-id="term_name">Default text</span>
  ```
+This will automatically be detected and translated when the `translator.translate()` method is called (see below)
 
  ### Getting a translated term in js code (`get`)
 

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -1,0 +1,46 @@
+# Language Translation
+
+## Overview
+
+
+| id | eng | spa | 
+| :--------- | :-------- |:--------- |
+| lang_name | English | Español |
+| lang_name_in_eng | English | Spanish |
+| language | Language | Idioma |
+| welcome | Welcome! | ¡Bienvenidos! |
+
+ - **Column names are required**
+ - **Column names should be a 3-letter code**, [ideally from this standard](https://en.wikipedia.org/wiki/ISO_639-2).
+
+```html
+<span data-translation-id="needs_money">Needs Money</span>
+```
+
+## Maintaining Translations
+
+### Translating existing terms
+
+### Creating a new term
+
+### Adding a new language
+
+#### Adding a column to the spreadsheet
+
+A checklist for adding a new column to the checklist
+
+ - [ ] The language header should contain a 3-letter code like `som` (a list of these can be [found here](https://en.wikipedia.org/wiki/ISO_639-2))
+
+#### Adding a new flag image
+
+A checklist for adding new flag images
+
+ - [ ] The image should be a PNG
+ - [ ] The image should be 23px wide
+ - [ ] The image name should have the format `lang-XXX.png` where "XXX" is the 3-letter language code
+ - [ ] The image should be placed in the `/public/images` directory in this repo
+
+#### Enabling the language
+
+
+## Technical Detials

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -2,8 +2,6 @@
 
 > **Note:** development on this project is moving quickly, so parts of this document may be out of date. Feel free to ask questions in the `#tc-aid-translations` channel in Slack.
 
-<!-- TOC -->autoauto- [Language Translation](#language-translation)auto  - [Overview](#overview)auto    - [The translation spreadsheet](#the-translation-spreadsheet)auto    - [Glossary](#glossary)auto    - [Special links](#special-links)auto  - [Maintaining Translations](#maintaining-translations)auto    - [Translating existing terms](#translating-existing-terms)auto    - [Creating a new term](#creating-a-new-term)auto    - [Adding a new language](#adding-a-new-language)auto      - [Adding a column to the spreadsheet](#adding-a-column-to-the-spreadsheet)auto      - [Adding a new flag image](#adding-a-new-flag-image)auto      - [Enabling the language](#enabling-the-language)auto  - [Technical Details](#technical-details)auto    - [`language`](#language)auto    - [`translate([<Element>])`](#translateelement)autoauto<!-- /TOC -->
-
 ## Overview
 
 The site translations work by loading a spreadsheet of translated terms, and replacing the hard-coded English terms on the page with the translated ones. If a translated term is missing in the spreadsheet, the English term will be used. The terms that need to be translated are specified **in the code**, it will **not** automatically find words on the page. 
@@ -12,11 +10,13 @@ A basic reference for what kind of access is needed for various actions in the t
 
 | Action | Edit Spreadsheet | Update code |
 | :-----------------| :-: | :-: |
-| Translating terms | No | No |
+| Translating terms* | No | No |
 | Adding translated terms | Yes | No |
 | Adding new terms | Yes | Yes | 
 | Adding a Language | Yes | Yes | 
 | Enabling a Language | No | Yes |
+
+* assuming the translator is working outside the main spreadsheet
 
 ### The translation spreadsheet
 

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -63,6 +63,8 @@ If you want to preview languages that have been created but not enabled, add `?d
 
 https://twin-cities-mutual-aid.org/?dev
 
+---
+
 ## Maintaining Translations
 
 ### Translating existing terms
@@ -91,7 +93,7 @@ Adding a language involves a few steps:
 
 #### Adding a column to the spreadsheet
 
-A checklist for adding a new column to the checklist
+Checklist:
 
  - [ ] The language header should contain a 3-letter code like `som` (a list of these can be [found here](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes)) 
 
@@ -129,6 +131,7 @@ A checklist for enabling a language:
  - [ ] 3-letter code is added to the array for dev/preview mode
  - [ ] 3-letter code is added to the array for production mode
 
+---
 
 ## Technical Details
 


### PR DESCRIPTION
### What
Add documentation for translation feature to address #106 and #131 

### Why
Make it easier to deal with translations

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [ ] Tapping on a marker on the map displays information about the marker in a popup.
- [ ] Tapping the "Show list of locations" button replaces the map view with a list view.
- [ ] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [ ] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [ ] Changing the language to spanish changes things on the page.
- [ ] Clicking the Help/Info button opens and closes a menu with information.
- [ ] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
