### PR TITLE
Add link to README for env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ A set variable in the `.env` file will look like this:
 SNOWPACK_PUBLIC_MAPBOXGL_ACCESS_TOKEN=1234
 ```
 
-Get the most recent values of the configuration values from the Open Twin Cities slack `#tc-aid-dev` channel. They are pinned in the channel.
+If you're a member of the Twin Cities Mutual Aid organization you can find the default values for the local development `env` file here:
+
+https://github.com/Twin-Cities-Mutual-Aid/secrets/blob/master/.env
+
+
+If not, you can ask for the most recent values of the configuration values from the Open Twin Cities slack `#tc-aid-dev` channel. They are pinned in the channel.
 
 If you need to introduce a new environmental variable, please coordinate with developers in the `#tc-aid-dev` channel, add it to the `.env.example` file, and note it in your pull request.
 


### PR DESCRIPTION
### What
Add link to default env file in new secret repo

### Why
It's hard to track this sort of thing on Slack

Resolves #135 