### PR TITLE
convert URLs in popup content to links

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,6 +215,21 @@ function addressComponent(address) {
   return `<address><a href="https://maps.google.com?saddr=Current+Location&daddr=${encodeURI(address)}" target="_blank">${address}</a></address>`;
 }
 
+// builds the section within the popup and replaces and URLs with links
+function sectionUrlComponent(value, key) {
+  let urls = extractUrl(value)
+  let sectionHTML = `<p class="p row"><p data-translation-id="${key}" class="txt-deemphasize
+  key">${key.toUpperCase()}</p><p class="value">${value}</p></p>`
+
+  if (urls) {
+    _.forEach(urls, url => {
+      sectionHTML = sectionHTML.replace(url, `<a href="${url}" target="_blank">${url}</a>`)
+    })
+  }
+
+  return sectionHTML
+}
+
 // get the status info for a location using the color as ID, else default to unknown.
 const getStatus = id => {
   const status = _.find(statusOptions, s => (s.id === id.toLowerCase()))
@@ -337,6 +352,16 @@ function getHours(openingHours, closingHours) {
   }
 }
 
+///////////
+// returns a an array of urls as strings if there is a match otherwise null
+// e.g. ['https://google.com']
+///////////
+function extractUrl(item) {
+  // regex source: https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
+  let url_pattern = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
+  return item.match(url_pattern)
+}
+
 function extractRawLocation(item) {
   return {
     name: item.gsx$nameoforganization.$t,
@@ -384,7 +409,10 @@ const onMapLoad = async () => {
           address: addressComponent, // driving directions in google, consider doing inside mapbox
           seekingMoney: (value, location) => needsMoneyComponent(location),
           seekingMoneyURL: (value, _) => '',
+          seekingVolunteers: (value, _) => sectionUrlComponent(value, 'seeking_volunteers'),
           mostRecentlyUpdatedAt: (datetime, _) => `<div class='updated-at' title='${datetime}'><span data-translation-id='last_updated'>Last updated</span> ${moment(datetime, 'H:m M/D').fromNow()}</div>`,
+          notes: (value, _) => sectionUrlComponent(value,'notes')
+          ,
           // ignore the following properties
           // marker and popup should not be rendered
           marker: () => '',


### PR DESCRIPTION
### What
This PR converts URLs in the content of the popup to clickable links. This PR does this for the "Seeking Volunteers" and "Notes" section.

<img width="349" alt="Screen Shot 2020-06-12 at 7 27 46 PM" src="https://user-images.githubusercontent.com/20211771/84555485-d8511400-ace2-11ea-9d35-9e051689ae7e.png">
<img width="353" alt="Screen Shot 2020-06-12 at 7 28 21 PM" src="https://user-images.githubusercontent.com/20211771/84555491-e4d56c80-ace2-11ea-81e0-ab458fd8d8cd.png">


### Why
This PR resolves #134 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [X] Tapping on a marker on the map displays information about the marker in a popup.
- [X] Tapping the "Show list of locations" button replaces the map view with a list view.
- [X] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [X] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [X] Changing the language to spanish changes things on the page.
- [X] Clicking the Help/Info button opens and closes a menu with information.
- [X] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [X] Chrome
- [X] Firefox
- [ ] Edge
- [X] Safari
