### PR TITLE
Change cursor to pointer on map marker hover

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -392,6 +392,10 @@ input[type='checkbox'] + label {
   padding: 0;
 }
 
+.mapboxgl-marker {
+  cursor: pointer
+}
+
 /* map marker toggles */
 .hide-recieving .status-recieving, .hide-distributing .status-distributing, .hide-both .status-both, .hide-closed .status-closed, .hide-unknown .status-unknown {
   display: none;


### PR DESCRIPTION
This changes the cursor to a pointer on map marker hover, to make it more clear that they are clickable.

I have no idea if this is the _right_ way to add styles to the mapbox marker, so I'd love @samanpwbb's perspective if there's a more appropriate way to do this.

(I couldn't take a screenshot because the cursor disappears from view whenever I tried)