### PR TITLE
convert URLs in popup content to links part 2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -411,10 +411,12 @@ const onMapLoad = async () => {
           address: addressComponent, // driving directions in google, consider doing inside mapbox
           seekingMoney: (value, location) => needsMoneyComponent(location),
           seekingMoneyURL: (value, _) => '',
+          accepting: (value, _) => sectionUrlComponent(value, 'accepting'),
+          notAccepting: (value, _) => sectionUrlComponent(value, 'not_accepting'),
           seekingVolunteers: (value, _) => sectionUrlComponent(value, 'seeking_volunteers'),
           mostRecentlyUpdatedAt: (datetime, _) => `<div class='updated-at' title='${datetime}'><span data-translation-id='last_updated'>Last updated</span> ${moment(datetime, 'H:m M/D').fromNow()}</div>`,
-          notes: (value, _) => sectionUrlComponent(value,'notes')
-          ,
+          urgentNeed: (value, _) => sectionUrlComponent(value,'urgent_need'),
+          notes: (value, _) => sectionUrlComponent(value,'notes'),
           // ignore the following properties
           // marker and popup should not be rendered
           marker: () => '',


### PR DESCRIPTION
### What
This PR converts URLs in the content of the popup to clickable links. This PR does this for the "Accepting", "Not Accepting", and "Urgent Needs" section.

### Why
Originally, [PR 168](https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/pull/168) only applied this change to the "Seeking Volunteers" and "Notes" section. However, a need for other columns was flagged by @comeoneileen in [Slack](https://opentwincities.slack.com/archives/C01525CPU5A/p1592021846431800?thread_ts=1592008433.420200&cid=C01525CPU5A).

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [X] Tapping on a marker on the map displays information about the marker in a popup.
- [X] Tapping the "Show list of locations" button replaces the map view with a list view.
- [X] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [X] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [X] Changing the language to spanish changes things on the page.
- [X] Clicking the Help/Info button opens and closes a menu with information.
- [X] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [X] Chrome
- [X] Firefox
- [ ] Edge
- [X] Safari
