### PR TITLE
Translations doc update + minor fix

### DIFF
--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -2,37 +2,29 @@
 
 > **Note:** development on this project is moving quickly, so parts of this document may be out of date. Feel free to ask questions in the `#tc-aid-translations` channel in Slack.
 
-1. Overview
-   1. The translation spreadsheet
-   2. Glossary
-   3. Special links
-2. Maintaining translations
-   1. Translating existing terms
-   2. Creating a new term
-   3. Adding a new language
-3. Technical details
-   1. Adding a term in markup (`data-translation-id`)
-   2. Getting a translated term in js code (`get`)
-   3. Setting the current language (`language`)
-   4. Running translation substitution (`translate`)
+1. [Overview](#Overview)
+   1. [The translation spreadsheet](#the-translation-spreadsheet) (**DEPRECATED**)
+   2. [Translation files](#translation-files)
+   3. [Special links](#special-links)
+2. [Maintaining translations](#maintaining-translations)
+   1. [Translating existing terms](#translating-existing-terms)
+   2. [Creating a new term](#creating-a-new-term)
+   3. [Adding a new language](#adding-a-new-language)
+3. [Technical details](#technical-details)
+   1. [Adding a term in markup (`data-translation-id`)](#adding-a-term-in-markup-data-translation-id)
+   2. [Getting a translated term in js code (`get`)](#getting-a-translated-term-in-js-code-get)
+   3. [Setting the current language (`language`)](#setting-the-current-language-language)
+   4. [Running translation substitution (`translate`)](#running-translation-substitution-translate)
 
 ## Overview
 
-The site translations work by loading a spreadsheet of translated terms, and replacing the hard-coded English terms on the page with the translated ones. If a translated term is missing in the spreadsheet, the English term will be used. The terms that need to be translated are specified **in the code**, it will **not** automatically find words on the page. 
+The site translations were originally loaded from a spreadsheet and have now been moved to `json` files that will be version controlled with the rest of the application.
 
-A basic reference for what kind of access is needed for various actions in the translation process. 
-
-| Action | Edit Spreadsheet | Update code |
-| :-----------------| :-: | :-: |
-| Translating terms* | No | No |
-| Adding translated terms | Yes | No |
-| Adding new terms | Yes | Yes | 
-| Adding a Language | Yes | Yes | 
-| Enabling a Language | No | Yes |
-
-*assuming the translator is working outside the main spreadsheet
+The site translations work by loading the translated terms from the corresponding files, and replacing the hard-coded English terms on the page with the translated ones. If a translated term is missing, the English term will be used. The terms that need to be translated are specified **in the code** in the `data-translation-id` attribute of the element. It will **not** automatically find words on the page.
 
 ### The translation spreadsheet
+
+> **Note:** The translation spreadsheet is no longer used by the application. The following section is here for historical purposes.
 
 The spreadsheet used for defining translations is here: https://docs.google.com/spreadsheets/d/1m5QPNP6O8nsQsqJcQbwib_obpXRjmbYYGtwKzzg1l38/edit?pli=1#gid=0. You can request access in the slack channel `#tc-aid-translations`.
 
@@ -47,11 +39,9 @@ Here's the basic format of the spreadsheet:
 
 The first column (the `id` column) and first row (e.g. `eng`) are **required** and must be filled out for any added row/column. The rest of the cells can be filled in as new translated terms are available.
 
-### Glossary
+### Translation files
 
- * **Languages:** Pretty self-explanatory (a column in the spreadsheet)
- * **Terms:** A word or set of words that need to be translated (a row in the spreadsheet). The term is identified by the `id` column
- * **Translated Terms:** An individual translated term (a cell in the spreadsheet)
+The translation files are located under [`src/i18n`](https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/tree/master/src/i18n). Each file represents a language where the filename follows the format `XXX.json` where XXX is the [`ISO 639-2`](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) code.
 
 ### Special links
 
@@ -59,43 +49,37 @@ If you want to link to a specific language (say you're sending the link to someb
 
 https://twin-cities-mutual-aid.org/?lang=som
 
-If you want to preview languages that have been created but not enabled, add `?dev` to the end of the url:
-
-https://twin-cities-mutual-aid.org/?dev
-
 ---
 
 ## Maintaining Translations
 
 ### Translating existing terms
 
-This is fairly straightforward, just add the term to the correct place in the spreadsheet :). Checklist:
-
- - [ ] The translated term is added to the correct column/row of the spreadsheet
+If there are missing translations for a specific language, add the appropriate `id` and translation and submit a pull request to get these changes approved and on the website.
 
 ### Creating a new term
 
 Checklist:
 
- - [ ] Create a new row in the spreadsheet for the new term
- - [ ] Make sure that there is a **unique** name in the `id` column, `formatted_like_this`
+ - [x] Create a new entry in `src/i18n/eng.json` with the corresponding `id` and term
+ - [x] Make sure that it is a **unique** `id` (`formatted_like_this`)
  - [ ] Make sure the term is also added to the correct place in the code, using either the `data-translation-id` attribute (in markup) or the `get` method (js code). See technical details below for more on this.
+ - [ ] If translations are not provided for every language, tag the pull request with **NEEDS TRANSLATIONS** so that the term can be translated by others.
 
 ### Adding a new language
 
 Adding a language involves a few steps:
 
-| Action | Edit Spreadsheet | Update code |
-| :-----------------| :-: | :-: |
-| 1. Adding a column to the spreadsheet | Yes | No |
-| 2. Adding a new flag image | No | Yes |
-| 3. Enabling the language | No | Yes | 
+1. Create a new translation `json` file
+2. Add a new flag image
+3. Check for matching [`moment.js`](https://momentjs.com/) translation
+4. Import translation in `translation.js`
 
-#### Adding a column to the spreadsheet
+#### Create a new translation file
 
-Checklist:
+To add a new language, you should first create a copy of [`eng.json`](https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/src/i18n/eng.json) and change the filename to the 3-letter [`ISO 639-2`](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) code.
 
- - [ ] The language header should contain a 3-letter code like `som` (a list of these can be [found here](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes)) 
+From there you can translate each term on the right side to the corresponding language.
 
 #### Adding a new flag image
 
@@ -110,26 +94,62 @@ A checklist for adding new flag images
  - [ ] The image name should have the format `lang-XXX.png` where "XXX" is the 3-letter language code
  - [ ] The image should be placed in the `/public/images` directory in this repo
 
-#### Enabling the language
+#### Moment.js
 
-Languages are currently enabled via a hard-coded list of enabled languages. At time of writing the languages are defined in code like this:
+We use [`moment.js`](https://momentjs.com/) to display text based on time computations ("an hour ago", "a few days ago", "in 3 days"). Some languages are already translated and supported by default. For others, we have created a translation file that will work with `moment.js` which can be found under [`src/locale`](https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/tree/master/src/locale).
+
+If the language is already supported by `moment.js`, the `locale` value in the `XXX.json` file should match the one that `moment.js` uses.
+
+If `moment.js` does not support the language, you should create a file in the `src/locale` directory with the format `XXX.js` where `XXX` is either a 2-letter [`ISO 639-1`](https://en.wikipedia.org/wiki/ISO_639-1) code if it exists or a 3-letter [`ISO 639-2`](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes). This `XXX` code should then be added to the `locale` value in the `XXX.json` file.
+
+Currently we are only translating the following terms:
 
 ```js
-// show all langs in dev mode
-if (window.location.search.indexOf('dev') > -1) {
-  langs = ['eng', 'spa', 'kar', 'som', 'hmn', 'amh', 'orm', 'vie']
-// otherwise only show these
-} else {
-  langs = ['eng', 'spa', 'som', 'amh', 'orm', 'vie']
+relativeTime: {
+   future: 'in %s',
+   past: '%s ago',
+   s: 'a few seconds',
+   ss: '%d seconds',
+   m: 'a minute',
+   mm: '%d minutes',
+   h: 'an hour',
+   hh: '%d hours',
+   d: 'a day',
+   dd: '%d days',
+   M: 'a month',
+   MM: '%d months',
+   y: 'a year',
+   yy: '%d years',
 }
 ```
 
-Note that there are **two** sets of language codes, one for preview mode and one for the live site.
+#### Enabling the language
 
-A checklist for enabling a language:
+Language files are imported in `translator.js` and added to the `this.languages` object in the constructor.
 
- - [ ] 3-letter code is added to the array for dev/preview mode
- - [ ] 3-letter code is added to the array for production mode
+```js
+constructor() {
+   this.languages = {
+   eng,
+   spa,
+   som,
+   hmn,
+   amh,
+   orm,
+   oji,
+   dak,
+   vie
+   }
+   this.detectLanguage()
+}
+```
+
+#### Add language checklist
+
+ - [ ] Create a new translation file (`src/i18n/XXX.json`)
+ - [ ] Add a new flag image (`public/images/lang-XXX.png`)
+ - [ ] `locale` should match existing `moment.js` translation or new `moment.js` locale created (`src/locale/XXX.js`)
+ - [ ] Language has been imported in `translation.js`
 
 ---
 

--- a/docs/LANGUAGE_TRANSLATION.md
+++ b/docs/LANGUAGE_TRANSLATION.md
@@ -61,8 +61,8 @@ If there are missing translations for a specific language, add the appropriate `
 
 Checklist:
 
- - [x] Create a new entry in `src/i18n/eng.json` with the corresponding `id` and term
- - [x] Make sure that it is a **unique** `id` (`formatted_like_this`)
+ - [ ] Create a new entry in `src/i18n/eng.json` with the corresponding `id` and term
+ - [ ] Make sure that it is a **unique** `id` (`formatted_like_this`)
  - [ ] Make sure the term is also added to the correct place in the code, using either the `data-translation-id` attribute (in markup) or the `get` method (js code). See technical details below for more on this.
  - [ ] If translations are not provided for every language, tag the pull request with **NEEDS TRANSLATIONS** so that the term can be translated by others.
 

--- a/specs/functional/language_button_spec.js
+++ b/specs/functional/language_button_spec.js
@@ -19,3 +19,23 @@ test('Switch language to Spanish', async t => {
     .expect(Selector('.lang-name').innerText).eql('Español')
     .expect(Selector('.title').textContent).contains('Mapa de Ayuda de las Ciudades Gemelas')
 })
+
+// Reloading the page should keep language preference
+test('Check that language has been saved', async t => {
+  await t
+    .click('#lang-select-button')
+    .expect(Selector('.welcome-message').visible).ok()
+    .click(Selector('.welcome-lang-button').withText('Español'))
+    .expect(Selector('.lang-name').innerText).eql('Español')
+
+  await t
+    // Reload the page
+    .eval(() => location.reload(true))
+  
+  await t
+    // Language should still be Spanish after reload
+    .expect(Selector('.lang-name').innerText).eql('Español')
+    .click('#lang-select-button')
+    // Welcome modal should be translated
+    .expect(Selector('.welcome-message').innerText).eql('¡Bienvenidos!')
+})

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,9 @@ const welcome = new WelcomeModal({
 
 if (translator.prompt) {
   welcome.open()
+} else {
+  // Translate welcome modal based on current on previously saved language
+  translator.translate(welcome.el)
 }
 
 // when language button is clicked, re-open welcome modal


### PR DESCRIPTION

### What
LANGUAGE_TRANSLATIONS.md update + minor fix on first load with corresponding test

### Why
There's an issue where if you have a saved language, reload the screen and open the language selector, it will not have been translated. Changing the language after that does update the  welcome modal so this problem is on first load specifically.

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari
