### PR TITLE
Use gtag config for bi-directional cross-domain measurement

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,10 +26,14 @@
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
-  gtag('set', 'linker', {'domains': ['twin-cities-mutual-aid.org', 'map.tcmap.org']});
   gtag('js', new Date());
 
-  gtag('config', 'UA-9313001-2', { 'anonymize_ip': true });
+  gtag('config', 'UA-9313001-2', { 
+    'anonymize_ip': true,
+    'linker': {
+      'domains': ['twin-cities-mutual-aid.org', 'map.tcmap.org']
+    } 
+  });
 </script>
 
 <body class='flex'>


### PR DESCRIPTION
### What
Works to accomplish the same thing as #180 , but with current/accurate use of gtag. 

### Why
The other cross-domain linking wasn't working, probably because it was an outdated method.

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [ ] Tapping on a marker on the map displays information about the marker in a popup.
- [ ] Tapping the "Show list of locations" button replaces the map view with a list view.
- [ ] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [ ] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [ ] Changing the language to spanish changes things on the page.
- [ ] Clicking the Help/Info button opens and closes a menu with information.
- [ ] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
