### PR TITLE
made volunteers needed sort by volunteers badge

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Twin Cities Aid Distribution Locations</title>
+  <title>Twin Cities Mutual Aid</title>
   <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
   <link rel="icon" href="favicon.ico">
 

--- a/src/index.js
+++ b/src/index.js
@@ -451,7 +451,7 @@ const onMapLoad = async () => {
           sort: { order: 'desc' }
         },
         {
-          name: 'seekingVolunteers',
+          name: 'seekingVolunteersBadge',
           label: 'Needs volunteers',
           sort: { order: 'desc' }
         }


### PR DESCRIPTION
### What
Fixed a bug in the volunteer sort so that it now sorts based on whether the "volunteers needed" badge is applied 

### Why
Sort by volunteers needed was not working properly

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
