### PR TITLE
Create fixed search bar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,7 @@
         <script type="text/javascript" src="//counter.websiteout.net/js/7/0/41000/0"></script>
       </div>
     </div>
+    <div id="search-controls"></div>
     <div id="side-pane" class="location-list">
       <div id="filter-controls"></div>
       <div class="list" id="location-list"></div>

--- a/src/js/filter.js
+++ b/src/js/filter.js
@@ -149,7 +149,6 @@ class Filter {
 
     this.$searchControl.innerHTML = `
     <form id="search-form" role="search" class="search-container" action="javascript:void(0);">
-    <button id="clear-search-btn" class="hide-clear-search" data-translation-id="search_clear">Clear Search</button>
         <div class="search-input-group search-full-width">
           <label for="search">
             <span class="sr-only">Type here to search sites or needs</span>
@@ -158,7 +157,8 @@ class Filter {
             <img src='images/search-icon.svg' alt='search icon'></img>
           </div>
           <input type="text" class="search-input" value="${this.searchOptions.initialSearch.replace(/\"/g, '')}" id="search" placeholder="Search sites or needs..." data-translation-id="search"></input>
-        </div>
+          </div>
+          <button id="clear-search-btn" class="hide-clear-search" data-translation-id="search_clear">Clear Search</button>
       </form>
       <div class="list-meta">
       <div class="list-results"><span id="list-results-count">${this.locations.length}</span> <span data-translation-id="list_results">results</span></div>

--- a/src/js/filter.js
+++ b/src/js/filter.js
@@ -12,6 +12,7 @@ class Filter {
     this.$filters = []
 
     this.$el = el
+    this.$searchControl = document.getElementById('search-controls')
     this.$controls = document.getElementById('filter-controls')
     this.renderControls(this.$controls)
     this.list = new List(this.$el.id, {
@@ -146,14 +147,9 @@ class Filter {
       return `<li class='filter-item'><input class="filter" type="checkbox" id="filter-${s.name}" value="${s.name}" checked><span class="legend--item--swatch" style="background-color: ${s.accessibleColor}"></span><label data-translation-id="filter_by_${_.snakeCase(s.name)}" for="filter-${s.name}">${s.label}</label><label> (${s.count})</label></li>`
     }).join('')
 
-    this.$controls.innerHTML = `
-      <div class="select-container">  
-        <label for="sort-by"><span data-translation-id="sort_by">Sort by</span>: </label>
-        <select name="sort-by" id="sort-by" data-translate-font>
-          ${options}
-        </select>
-      </div>
-      <form id="search-form" role="search" class="search-container" action="javascript:void(0);">
+    this.$searchControl.innerHTML = `
+    <form id="search-form" role="search" class="search-container" action="javascript:void(0);">
+    <button id="clear-search-btn" class="hide-clear-search" data-translation-id="search_clear">Clear Search</button>
         <div class="search-input-group search-full-width">
           <label for="search">
             <span class="sr-only">Type here to search sites or needs</span>
@@ -163,10 +159,18 @@ class Filter {
           </div>
           <input type="text" class="search-input" value="${this.searchOptions.initialSearch.replace(/\"/g, '')}" id="search" placeholder="Search sites or needs..." data-translation-id="search"></input>
         </div>
-        <button id="clear-search-btn" class="hide-clear-search" data-translation-id="search_clear">Clear Search</button>
       </form>
       <div class="list-meta">
-        <div class="list-results"><span id="list-results-count">${this.locations.length}</span> <span data-translation-id="list_results">results</span></div>
+      <div class="list-results"><span id="list-results-count">${this.locations.length}</span> <span data-translation-id="list_results">results</span></div>
+    </div>
+    `
+
+    this.$controls.innerHTML = `
+      <div class="select-container">
+        <label for="sort-by"><span data-translation-id="sort_by">Sort by</span>: </label>
+        <select name="sort-by" id="sort-by" data-translate-font>
+          ${options}
+        </select>
       </div>
     `
 

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -2,48 +2,72 @@
 	display: flex;
 	flex-wrap: nowrap;
 	align-items: center;
-	margin: 15px 0;
+	margin: 0px 0;
 	position: relative;
+	padding-right: 10px;
+	padding-left: 15px;
+}
+
+#search-controls {
+	background-color: rgba(0,0,50,.9);
+	color: white;
+	padding: 0px 5px 0px 0px;
 }
 
 #search-icon {
 	position: absolute;
 	top: px;
-	left: 4px;
+	right: 10px;
 }
 
 .search-input {
 	padding: 10px;
-	border: 1px solid black;
+	border: none;
 	height: 30px;
-	max-width: 100%;
-	padding-left: 30px;
+	width: 100%;
+	border-radius: 3px;
 }
 
-@media (max-width: 1118px) {
+.search-input:focus {
+	border: round;
+}
+
+@media (max-width: 2000px) {
 	.search-input-group {
-		width: 60%;
+		width: 80%;
+	}
+}
+
+@media (max-width: 950px) {
+	.search-input-group {
+		width: 70%;
+	}
+}
+
+@media (max-width:635px) {
+	.search-input-group {
+		width: 80%;
 	}
 }
 
 #clear-search-btn {
 	min-height: 30px;
-	margin-left: 5px;
+	margin-right: 8px;
 	background-color: #B33C22;
 	border-radius: 3px;
 	color: white;
+	border: none;
+	box-shadow: 0px 0px 4px rgba(255, 255, 255, 0.9);
 }
 
-@media (max-width: 1118px) {
+@media (max-width: 2000px) {
 	#clear-search-btn {
-		width: 40%;
+		width: 115px;
 		padding: 0;
-		margin-left: 5px;
-		flex-grow: 1;
 	}
 }
 
-@media(max-width: 1118px) {
+@media(max-width: 2000px) {
 	.search-full-width {
 		width: 100%;
 	}

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -17,7 +17,7 @@
 #search-icon {
 	position: absolute;
 	top: px;
-	right: 10px;
+	left: 13px;
 }
 
 .search-input {
@@ -26,10 +26,12 @@
 	height: 30px;
 	width: 100%;
 	border-radius: 3px;
+	padding-left: 25px;
 }
 
 .search-input:focus {
 	border: round;
+	outline-color: #80bdff;
 }
 
 @media (max-width: 2000px) {
@@ -52,17 +54,17 @@
 
 #clear-search-btn {
 	min-height: 30px;
-	margin-right: 8px;
+	margin-left: 5px;
 	background-color: #B33C22;
 	border-radius: 3px;
 	color: white;
 	border: none;
-	box-shadow: 0px 0px 4px rgba(255, 255, 255, 0.9);
+	box-shadow: 0px 0px 5px rgba(255, 255, 255, 0.9);
 }
 
 @media (max-width: 2000px) {
 	#clear-search-btn {
-		width: 115px;
+		width: 110px;
 		padding: 0;
 	}
 }

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -195,6 +195,7 @@ input[type='checkbox'] + label {
 .list-results {
   display: block;
   font-weight: bold;
+  padding-right: 10px;
 }
 
 .loading-indicator {


### PR DESCRIPTION
### What
Moved the search bar to a fixed location beneath the site legend. Moved the "clear search" button to the left to make it more intuitive. Updated the styling of the search bar and "clear search" button to be more consistent with the style of the surrounding elements. 

### Why
The search bar used to be hidden by default on mobile devices with no clear indication of how to access it, and on all devices, the search bar would scroll out of view if navigating through the side-pane. 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari
