### PR TITLE
Adding the disclaimer to the help/info section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,9 @@
     <p class='p txt-small bold'><span data-translation-id="project_feedback">Have feedback?</span> <a href="mailto:support@tcmap.org" data-translation-id="project_contact">Email Us</a>.</p>
     <p class='p txt-small bold'><span data-translation-id="project_data">See this data in</span> <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vSfnmh9CmtVoBMy2k_-NMhhvF7ursBs2L5IPF9VZ1J-l9P71vjDFw7y6Y6E98d5lNeOAEo7leisP0Y8/pubhtml" target="_blank">Google Sheets</a>.</p>
     <p class='p txt-small bold'><span data-translation-id="project_learn">Learn about this project on</span> <a href="https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/blob/master/README.md" target="_blank">GitHub</a>.</p>
+    <p class='p txt-extra-small italic'><span data-translation-id="disclaimer">TCMAP aggregates, compiles, and logs information on our maps solely through the work of volunteers. We cannot guarantee the complete accuracy of this information, 
+      including usernames or accounts provided for direct donations. Your use of this website is completely voluntary, and you assume any and all risks and liabilities, financial or otherwise, with providing goods, services, or funds to any distribution site listen on our map. 
+      TCMAP does not assume any responsibility for your use of this website and has no obligation to provide users with financial or other assistance.</span></p>
   </div>
   <div class='map' id="map">
     <button class="lang-select-button" id="lang-select-button">

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -112,6 +112,10 @@ a.txt-white:hover {
   font-size: 13px;
 }
 
+.txt-extra-small {
+  font-size: 10px;
+}
+
 .txt-deemphasize {
   opacity: 0.70;
   font-size: 0.9em;
@@ -119,6 +123,10 @@ a.txt-white:hover {
 
 .bold {
   font-weight: 600;
+}
+
+.italic{
+  font-style: italic;
 }
 
 .padded {


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
_Adds the disclaimer from the website's FAQ section to the help/info section of the map, smaller and italicized._

### Why
_The lawyer recommended we do this and there's plenty of space in that section._

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to Spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
