### PR TITLE
fix the accents for Vietnamese language

### DIFF
--- a/src/i18n/vie.json
+++ b/src/i18n/vie.json
@@ -1,7 +1,7 @@
 
 {
   "locale": "vi",
-  "lang_name": "Tiéng Viêt",
+  "lang_name": "Tiếng Việt",
   "lang_name_in_eng": "Vietnamese",
   "language": "Ngôn ngữ",
   "welcome": "Chào mừng ",


### PR DESCRIPTION
### What
Accent marks for the Vietnamese language selection were incorrect, updated them per recommendation of Simi in TCMAP

### Why
Resolve inaccurate accent marks in Vietnamese language selection

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
