### PR TITLE
Add gtag analytics for outbound link clicks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,16 @@
       'domains': ['twin-cities-mutual-aid.org', 'map.tcmap.org']
     } 
   });
+
+  // Capture outbound link events for analytics using gtag.js framework 
+  // https://support.google.com/analytics/answer/7478520?hl=en
+  const captureOutboundLink = function(url, linkClass) {
+    gtag('event', 'click', {
+      'event_category': linkClass + ' link',
+      'event_label': url,
+      'transport_type': 'beacon'
+    });
+  }
 </script>
 
 <body class='flex'>

--- a/src/index.js
+++ b/src/index.js
@@ -281,8 +281,6 @@ const createListItem = (location, status, lng, lat) => {
   return $item
 }
 
-
-
 //////////////////////////
 // Protect against columns not yet existing in the spreadsheet.
 // We can remove once they are added to the sheet.

--- a/src/index.js
+++ b/src/index.js
@@ -171,13 +171,14 @@ function needsMoneyComponent(location) {
 
   let link = '';
   if (location.seekingMoneyURL && location.seekingMoneyURL !== '') {
-    link = `<a data-translation-id="seeking_money_link" href="${location.seekingMoneyURL}" target="_blank">DONATE NOW!</a>`;
+    link = `<a data-translation-id="seeking_money_link" href="${location.seekingMoneyURL}" target="_blank" onclick="captureOutboundLink('${location.seekingMoneyURL}', 'donation')">DONATE NOW!</a>`;
   }
   return `<span  class="seekingMoney seeking-money location-list--badge"><span data-translation-id="seeking_money">Needs Money</span> ${link}</span>`;
 }
 
 function addressComponent(address) {
-  return `<address><a href="https://maps.google.com?saddr=Current+Location&daddr=${encodeURI(address)}" target="_blank">${address}</a></address>`;
+  const googleMapDirections = `https://maps.google.com?saddr=Current+Location&daddr=${encodeURI(address)}`
+  return `<address><a href="${googleMapDirections}" target="_blank" onclick="captureOutboundLink('${googleMapDirections}', 'directions')">${address}</a></address>`;
 }
 
 // builds the section within the popup and replaces and URLs with links
@@ -188,7 +189,7 @@ function sectionUrlComponent(value, key) {
 
   if (urls) {
     _.forEach(urls, url => {
-      sectionHTML = sectionHTML.replace(url, `<a href="${url}" target="_blank">${url}</a>`)
+      sectionHTML = sectionHTML.replace(url, `<a href="${url}" target="_blank" onclick="captureOutboundLink('${url}', '${key}')">${url}</a>`)
     })
   }
 
@@ -279,6 +280,8 @@ const createListItem = (location, status, lng, lat) => {
   })
   return $item
 }
+
+
 
 //////////////////////////
 // Protect against columns not yet existing in the spreadsheet.


### PR DESCRIPTION
### What
Add gtag analytics to capture outbound link clicks

### Why
To improve analytics as per https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/issues/184

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari
