### PR TITLE
fix link behavior to allow lack of web protocol and ignore end punctuation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,7 +189,9 @@ function sectionUrlComponent(value, key) {
 
   if (urls) {
     _.forEach(urls, url => {
-      sectionHTML = sectionHTML.replace(url, `<a href="${url}" target="_blank" onclick="captureOutboundLink('${url}', '${key}')">${url}</a>`)
+      let target_url = url;
+      if (!(/http/i.test(url))) target_url = 'http://' + url;
+      sectionHTML = sectionHTML.replace(url, `<a href="${target_url}" target="_blank" onclick="captureOutboundLink('${target_url}', '${key}')">${url}</a>`)
     })
   }
 
@@ -322,8 +324,8 @@ function getHours(openingHours, closingHours) {
 // e.g. ['https://google.com']
 ///////////
 function extractUrl(item) {
-  // regex source: https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
-  let url_pattern = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
+  //regex source: https://stackoverflow.com/questions/6927719/url-regex-does-not-work-in-javascript
+  let url_pattern = /\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/gi;
   return item.match(url_pattern)
 }
 


### PR DESCRIPTION
### What
Fix the regex for extractUrl so that it doesn't capture punctuation at the end of urls, and inject http:// into the url string when it is missing so that the <a href...> tag works. 

### Why
Prior to this change, something like 'www.google.com,' wouldn't work for two reasons; the trailing comma would have been included in the url, and the lack of an explicit protocol at the beginning rendered the link unusable. 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
