### PR TITLE
fix volunteer display in popup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -384,7 +384,7 @@ const onMapLoad = async () => {
           seekingMoneyURL: (value, _) => '',
           accepting: (value, _) => sectionUrlComponent(value, 'accepting'),
           notAccepting: (value, _) => sectionUrlComponent(value, 'not_accepting'),
-          seekingVolunteers: (value, _) => sectionUrlComponent(value, 'seeking_volunteers'),
+          seekingVolunteers: (value, _) => sectionUrlComponent(value, 'seeking_volunteers_badge'),
           mostRecentlyUpdatedAt: (datetime, _) => `<div class='updated-at' title='${datetime}'><span data-translation-id='last_updated'>Last updated</span> <span data-translate-font>${moment(datetime, 'H:m M/D').fromNow()}</span></div>`,
           urgentNeed: (value, _) => sectionUrlComponent(value,'urgent_need'),
           notes: (value, _) => sectionUrlComponent(value,'notes'),


### PR DESCRIPTION

### What
Fixing display of pop-up for the volunteers section

### Why
Because it was displaying incorrectly

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [ ] Tapping on a marker on the map displays information about the marker in a popup.
- [ ] Tapping the "Show list of locations" button replaces the map view with a list view.
- [ ] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [ ] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [ ] Changing the language to spanish changes things on the page.
- [ ] Clicking the Help/Info button opens and closes a menu with information.
- [ ] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
