### PR TITLE
Increase Popup Max-Width to 600px

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -403,7 +403,7 @@ const onMapLoad = async () => {
         // create marker
         location.marker = new mapboxgl.Marker({ color: status.accessibleColor })
           .setLngLat([ parseFloat(item.gsx$longitude.$t), parseFloat(item.gsx$latitude.$t) ])
-          .setPopup(new mapboxgl.Popup().setMaxWidth('275px'))
+          .setPopup(new mapboxgl.Popup().setMaxWidth('600px'))
           .addTo(map);
 
           location.marker.getElement().className += " status-" + status.name;


### PR DESCRIPTION
### What
This PR increases the max-width of the popup to 600 pixels.

### Why
This looks much better on larger screens. Originally the small 275px width was used because scrolling was difficult.

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [ ] Tapping on a marker on the map displays information about the marker in a popup.
- [ ] Tapping the "Show list of locations" button replaces the map view with a list view.
- [ ] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [ ] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [ ] Changing the language to spanish changes things on the page.
- [ ] Clicking the Help/Info button opens and closes a menu with information.
- [ ] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
