### PR TITLE
Add user location to map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,16 @@ map.setPadding({ top: 300, bottom: 20, left: 20, right: 20 })
 // Add zoom and rotate controls
 map.addControl(new mapboxgl.NavigationControl(), 'bottom-right');
 
+map.addControl(
+  new mapboxgl.GeolocateControl(
+    {
+      positionOptions: {
+        enableHighAccuracy: true
+      },
+      trackUserLocation: false
+    }), 'bottom-right'
+);
+
 // convert case
 function camelToTitle(str) {
   const result = str.replace(/([A-Z])/g,' $1')


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Add geolocate button to map that user can press to zoom in on their location.

### Why
Addresses this issue: https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/issues/220

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari
