### PR TITLE
Add line breaks in map popups from line breaks in google sheets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,8 +198,17 @@ function addressComponent(address) {
 // builds the section within the popup and replaces and URLs with links
 function sectionUrlComponent(value, key) {
   let urls = extractUrl(value)
-  let sectionHTML = `<p class="p row"><p data-translation-id="${key}" class="txt-deemphasize
-  key">${key.toUpperCase()}</p><p class="value">${value}</p></p>`
+  let parsedText = parseLineBreaks(value)
+  let sectionHTML = `
+    <p class="p row">
+      <p data-translation-id="${key}" class="txt-deemphasize key">
+        ${key.toUpperCase()}
+      </p>
+      <p class="value">
+        ${parsedText}
+      </p>
+    </p>
+  `
 
   if (urls) {
     _.forEach(urls, url => {
@@ -341,6 +350,10 @@ function extractUrl(item) {
   //regex source: https://stackoverflow.com/questions/6927719/url-regex-does-not-work-in-javascript
   let url_pattern = /\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/gi;
   return item.match(url_pattern)
+}
+
+function parseLineBreaks(value) {
+  return value.replace('\n', '<br /><br />');
 }
 
 function extractRawLocation(item) {


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Add line break in map popup text to match line breaks from google sheets. Currently, adds a full blank space between paragraphs. I can change to just add a newline if that would be preferred.

### Why
https://github.com/Twin-Cities-Mutual-Aid/twin-cities-aid-distribution-locations/issues/231

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari
