### PR TITLE
Pull to refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8691,6 +8691,12 @@
         }
       }
     },
+    "pulltorefreshjs": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/pulltorefreshjs/-/pulltorefreshjs-0.1.20.tgz",
+      "integrity": "sha512-ezJLhM1dXoNJ2Sx5tRAp4QPqI7jfQfHAHdVd6gQgNPfpIC5v6v/TTesgPQT2aFxEmqiTemWCQrmliaCxqRAYiA==",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@snowpack/plugin-babel": "^1.0.0",
     "@snowpack/plugin-dotenv": "^1.1.1",
     "@snowpack/plugin-webpack": "^1.2.0",
+    "pulltorefreshjs": "^0.1.20",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "snowpack": "^2.5.1",
     "testcafe": "^1.8.6"

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
   <title>Twin Cities Mutual Aid</title>
   <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
   <link rel="icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
+  <script src="https://kit.fontawesome.com/5438b173e4.js" crossorigin="anonymous"></script>
 
   <!-- META TAGS -->
   <meta property="og:image" content="https://twin-cities-mutual-aid.org/images/aid2.png">

--- a/public/index.html
+++ b/public/index.html
@@ -57,9 +57,6 @@
       <div class='legend' id="key"></div>
       <button data-translation-id="show_list_button" id="locations-toggle-button" class="location-list-toggle toggle-button" aria-label="Show list of locations">Show list of locations</button>
       <button data-translation-id="help_info" id="help-info-toggle-button" class="toggle-button" aria-label="Toggle help info section">Help/info</button>
-      <button data-translation-id="refresh_button" id='refresh-page-button' class='toggle-button' aria-label="refresh page data">
-        <img class="refresh-image" alt="${lang_name}" src="/images/refresh.png">
-        <span class="refresh-text" data-translation-id="refresh">Refresh</span></button>
       <div class='counter'>
         <script type="text/javascript" src="//counter.websiteout.net/js/7/0/41000/0"></script>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,6 @@
   <title>Twin Cities Mutual Aid</title>
   <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
   <link rel="icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
   <script src="https://kit.fontawesome.com/5438b173e4.js" crossorigin="anonymous"></script>
 
   <!-- META TAGS -->

--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,7 @@
 
 <body class='flex'>
   <div class="content">
+    <div id="header">
     <div class="title white-and-blue">
       <h1 data-translation-id="page_title" class='h1'>Twin Cities Mutual Aid Map</h1>
     </div>
@@ -64,6 +65,7 @@
       </div>
     </div>
     <div id="search-controls"></div>
+    </div>
     <div id="side-pane" class="location-list">
       <div id="filter-controls"></div>
       <div class="list" id="location-list"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -180,10 +180,6 @@ function toggleSidePane() {
     $locationsButton.setAttribute('aria-label', buttonText)
   }
 }
-//refresh page data
-function refreshPage() {
-  location.reload();
-}
 
 // open/close help info
 function toggleHelpInfo() {
@@ -572,12 +568,6 @@ const helpInfoCloseButton = document.getElementById('help-info-close-button')
 helpInfoCloseButton.addEventListener("click", function(){
   toggleHelpInfo()
 });
-
-//add refresh page handler
-const refreshPageButton = document.getElementById('refresh-page-button')
-refreshPageButton.addEventListener("click", function() {
-  refreshPage()
-})
 
 // render key
 const key = document.getElementById('key')

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import { getQueryParam } from './js/url-helpers';
 import { TrackJS } from 'trackjs';
 import validate, { LOCATION_SCHEMA } from "./js/validator";
 import replaceAll from 'string.prototype.replaceall'
+import PullToRefresh from 'pulltorefreshjs'
 
 //Add TrackJS Agent
 if(import.meta.env.MODE === 'production'){
@@ -91,6 +92,20 @@ const statusOptions = [
 let activePopup
 const translator = new Translator()
 moment.locale(translator.locale)
+
+const ptr = PullToRefresh.init({
+  mainElement: "body",
+  triggerElement: "#header",
+  instructionsPullToRefresh: " ",
+  iconArrow: " ",
+  iconRefreshing: " ",
+  instructionsRefreshing: '<h1><i class="fas fa-spinner fa-spin"></i></h1>',
+  instructionsReleaseToRefresh: '<h1><i class="fas fa-spinner"></i></div>',
+  instructionsPullToRefresh: '<h1><i class="fas fa-spinner"></i></h1>',
+  onRefresh() {
+    window.location.reload();
+  }
+});
 
 const welcome = new WelcomeModal({
   languages: translator.languages,

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -29,7 +29,7 @@ a.txt-white:hover {
 }
 
 .map,
-.help-info, .refresh-page-button {
+.help-info {
   left: 0;
   top: 0;
   right: 0;
@@ -251,21 +251,6 @@ input[type='checkbox'] + label {
 
 /* component: location list toggle */
 .location-list-toggle {
-  display: none;
-}
-
-/*component: refresh page button*/
-
-.refresh-image {
-  display: inline-block;
-  vertical-align: top;
-  margin: 0 0px;
-  width: 13px;
-  /* hide alt text if image is missing */
-  text-indent: -9999px;
-}
-
-.refresh-text {
   display: none;
 }
 


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Add pull to refresh functionality for mobile and remove the refresh button. Since all web browsers have a visible refresh button built in, it's not required to include is as an explicit button on the page. Also, pull-to-refresh is a fairly intuitive action on mobile devices so should be pretty natural fo most users.

### Why
Opens up screen real estate

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari
