### PR TITLE
remove some info required separate section from popup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -443,11 +443,11 @@ function extractRawLocation(item) {
     urgentNeed: item.gsx$urgentneed.$t,
     seekingMoney: extractSeekingMoney(item),
     seekingMoneyURL: extractSeekingMoneyURL(item),
+    noIdNeeded: item.gsx$noidneeded.$t,
+    someInfoRequired: item.gsx$someinforequiredchecknoidtoo.$t,
     accepting: item.gsx$accepting.$t,
     notAccepting: item.gsx$notaccepting.$t,
     seekingVolunteers: item.gsx$seekingvolunteers.$t,
-    noIdNeeded: item.gsx$noidneeded.$t,
-    someInfoRequired: item.gsx$someinforequiredchecknoidtoo.$t,
     notes: item.gsx$notes.$t
   }
 }
@@ -482,6 +482,7 @@ const onMapLoad = async () => {
           seekingMoney: (value, location) => needsMoneyComponent(location),
           seekingMoneyURL: (value, _) => '',
           noIdNeeded: (_, location) => noIdNeededComponent(location),
+          someInfoRequired: (value, _) => '',
           accepting: (value, _) => sectionUrlComponent(value, 'accepting'),
           notAccepting: (value, _) => sectionUrlComponent(value, 'not_accepting'),
           seekingVolunteers: (value, _) => sectionUrlComponent(value, 'seeking_volunteers_badge'),

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -295,13 +295,13 @@ input[type='checkbox'] + label {
 }
 
 .popup-content .key {
-  padding: 0px;
+  padding: 5px 0 0 0;
   margin: 0px;
   border-bottom: 1px solid #ddd;
 }
 
 .popup-content .value {
-  padding: 5px 0 10px 0;
+  padding: 5px 0 5px 0;
   margin: 0px;
 }
 


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Remove `Some Info Required` sections from popups. Move popup id badge next to money badge so all badges are in same location. 

### Why
`Some Info Required` was showing up as separate section on popups with TRUE or FALSE - not needed as the value is represented by the presence of the tag or not. Adjusted spacing of the popup a tiny bit so the tags were not smushed up against the next section on the popup.

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari
