### PR TITLE
Analytics: update "language_change" Event to better represent users actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,11 +108,21 @@ const ptr = PullToRefresh.init({
   }
 });
 
+/**
+ * set which languages to display
+ * update the language choice when a user selects a new language
+ * Send GA event to track language choice
+ * if there's an active popup, re-display it after the welcome modal closes
+ */
 const welcome = new WelcomeModal({
   languages: translator.languages,
   onLanguageSelect: lang => {
     translator.language = lang
     moment.locale(translator.locale)
+    gtag('event', 'language_change', {
+      'event_category': 'language',
+      'event_label': lang
+    })
     activePopup && activePopup.refreshPopup()
   }
 })

--- a/src/js/translator.js
+++ b/src/js/translator.js
@@ -143,14 +143,9 @@ class Translator {
    * Sets language throughout the page
    * - Find and set images with the `data-translation-flag`
    * - Set <html lang="??">
-   * - Send GA event to track language choice
    */
   setDocumentLanguage() {
     document.documentElement.lang = this.locale
-    gtag('event', 'language_change', {
-      'event_category': 'language',
-      'event_label': this.language
-    })
   }
 }
 


### PR DESCRIPTION

### What
_Brief description of changes._
Update the Google Analytics language_change event so it only triggers when the user first comes to the website, and every time they open the welcome popup and select a language. It used to be triggering every time someone would reload the page as well

### Why
_What problem does this pull requests solve?  Reference related issues if appropriate._
To fix issue #178, also related to #154 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Safari
