### PR TITLE
Stop displaying hours banner"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -92,10 +92,10 @@
       <i class="material-icons-round close-icon" alt="close covid banner">close</i>
     </div>
   </div>
-  <div id="hours-banner" class="hours-banner">
+  <div id="hours-banner" class="hours-banner" style="display:none;">
     <div class="hours-message">
       <i class="material-icons-round close-icon" alt="hours banner">schedule</i>
-      <h4 data-translation-id="">Hours may vary  Nov 25 - Nov 29</h4>
+      <h4 data-translation-id="">Hours may vary Nov 25 - Nov 29</h4>
       <h4 data-translation-id="" class="due-to-holiday">&nbsp;due to holiday.</h4>
     </div>  
     <div id="close-hours-banner-button" class="close-hours-banner">


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Set hours banner to not display.

### Why
Not relevant anymore (but will be relevant in a few weeks again so leaving code in place)

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
