### PR TITLE
Try removing animate from hiatus close

### DIFF
--- a/src/js/hiatus-modal.js
+++ b/src/js/hiatus-modal.js
@@ -15,7 +15,7 @@ class HiatusModal {
         //Alternately, allow user to click outside modal to close
         this.closeButton.addEventListener('click', () => {
             this.close()})
-         document.addEventListener('keyup', (evt) => {
+        document.addEventListener('keyup', (evt) => {
             if (evt.key === 'Escape'){
                 this.close()}
             })
@@ -53,12 +53,7 @@ class HiatusModal {
         sessionStorage.setItem("alertshown", true); //changing 'true' here shouldn't do anything?
     }
     close() {
-        this.el.animate([
-            {opacity: 1},
-            {opacity: 0} 
-        ], 400);
-        setTimeout( () => {
-            this.el.remove()}, 350);
+        this.el.remove()
     }    
 }
 


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Bugfix - remove animate from modal close

### Why
_What problem does this pull requests solve?  Reference related issues if appropriate._

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari
