### PR TITLE
remove hiatus banner and hiatus modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -92,7 +92,7 @@
       <i class="material-icons-round close-icon" alt="close covid banner">close</i>
     </div>
   </div>
-  <div id="hours-banner" class="hiatus-banner" style="display:visible;">
+  <div id="hours-banner" class="hiatus-banner" style="display:none;">
     <div class="hours-message">
       <i class="material-icons-round close-icon" alt="hours banner">warning</i>
       <h4 data-translation-id="" class="due-to-holiday">TCMAP is on hiatus. </h4>

--- a/public/index.html
+++ b/public/index.html
@@ -57,7 +57,7 @@
     </a>
   </div>
 
-  <div id="covid-banner" class="covid-banner" style="display:none;">
+  <div id="covid-banner" class="covid-banner">
     <div class="covid-banner-reminder">
       <div class="safety-reminder">
         <i class="material-icons-round covid-warning-icon" aria-hidden="true">error</i>

--- a/specs/helpers.js
+++ b/specs/helpers.js
@@ -5,10 +5,9 @@ export const beforeEachTest = async t => {
     // Language must be selected before anything else can be done
     .click(Selector('.welcome-lang-button').withText('English'))
     // Hiatus modal must be cleared before tests
-      .click(Selector('.modal-close'))
+    // .click(Selector('.modal-close'))
     // Help window should not be visible at beginning
     .expect(Selector('#help-info').visible).notOk()
-  
   
 }
 

--- a/specs/helpers.js
+++ b/specs/helpers.js
@@ -4,8 +4,6 @@ export const beforeEachTest = async t => {
   await t
     // Language must be selected before anything else can be done
     .click(Selector('.welcome-lang-button').withText('English'))
-    // Hiatus modal must be cleared before tests
-    // .click(Selector('.modal-close'))
     // Help window should not be visible at beginning
     .expect(Selector('#help-info').visible).notOk()
   

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ import './styles/components/form-control.css';
 import './styles/components/search.css';
 import './styles/components/covid-banner.css';
 import './styles/components/hours-banner.css';
-import './styles/components/hiatus-modal.css';
 import './styles/typography.css';
 
 // Import Libs
@@ -22,7 +21,6 @@ import _ from 'lodash'
 import Filter from './js/filter'
 import Translator from './js/translator'
 import WelcomeModal from './js/welcome'
-import HiatusModal from './js/hiatus-modal'
 import { getQueryParam } from './js/url-helpers';
 import { TrackJS } from 'trackjs';
 import validate, { LOCATION_SCHEMA } from "./js/validator";
@@ -140,26 +138,6 @@ if (translator.prompt) {
 
 // when language button is clicked, re-open welcome modal
 document.getElementById('lang-select-button').addEventListener('click', () => welcome.open())
-
-
-/* show hiatus alertdialog modal if active and not already in user's session
-*  if language not set (translator.prompt), wait for user to click welcome modal button before opening
-* (change activeStatus to false in 'src/js/hiatus-modal.js' to disable) */
-const hiatusAlert = new HiatusModal;
-if (hiatusAlert.isActive && !sessionStorage.getItem('alertshown')) {
-  if (translator.prompt) { 
-    document.querySelectorAll('.welcome-lang-button').forEach(button => {
-      button.addEventListener('click', () => {
-        setTimeout( () => {
-          hiatusAlert.open()}, 600);
-      });
-    })
-  }
-  else {
-    hiatusAlert.open();
-  } 
-}
-
 
 document.getElementById('close-covid-banner-button').addEventListener('click', () => closeCovidBanner())
 

--- a/src/js/hiatus-modal.js
+++ b/src/js/hiatus-modal.js
@@ -8,7 +8,7 @@ class HiatusModal {
         this.el.className = 'modal-wrap';
         this.el.innerHTML = this.render();
         this.closeButton = this.el.querySelector(".modal-close");
-        this.isActive = true; //change this to 'false' to disable the modal
+        this.isActive = false; //change this to 'false' to disable the modal
 
         //Add event listeners to close button
         //Add event listener to close button using escape key


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Remove hiatus banner and modal (will not be merging until later tonight)

### Why
Hiatus will be over tonight 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari
