### PR TITLE
removed 'not accepting' from search fields

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -327,7 +327,7 @@ function getStatus(item) {
 
 // Not all the fields being searched on should be visible but need
 // to be on the DOM in order for listjs to pick them up for search
-const hiddenSearchFields = ['address', 'accepting', 'notAccepting', 'notes', 'seekingVolunteers']
+const hiddenSearchFields = ['address', 'accepting', 'notes', 'seekingVolunteers']
 
 const hiddenSearchComponent = (field, value) => (
   `<p class="${field}" style="display:none">${value || '' }</p>`


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Removed "Not Accepting" from list of searchable fields.

### Why
Currently, search results include sites where a search query is listed in the "Not Accepting" category. This leads to false positives in the context of what is reasonable to consider the most common user intent (to locate sites where an item can be donated or received). E.g., a search for "clothing" returns both sites that _are accepting_ clothing and sites that _are not accepting_ clothing which is confusing and unhelpful for the user. 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x]  Changing the language to spanish changes things on the page.
- [x]  Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Safari
