### PR TITLE
Hide memorial day banner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -92,7 +92,7 @@
       <i class="material-icons-round close-icon" alt="close covid banner">close</i>
     </div>
   </div>
-  <div id="hours-banner" class="hours-banner" style="display:visible;">
+  <div id="hours-banner" class="hours-banner" style="display:none;">
     <div class="hours-message">
       <i class="material-icons-round close-icon" alt="hours banner">schedule</i>
       <h4 data-translation-id="" >Hours may vary May 31</h4>

--- a/src/index.js
+++ b/src/index.js
@@ -327,7 +327,7 @@ function getStatus(item) {
 
 // Not all the fields being searched on should be visible but need
 // to be on the DOM in order for listjs to pick them up for search
-const hiddenSearchFields = ['address', 'accepting', 'notAccepting', 'notes', 'seekingVolunteers']
+const hiddenSearchFields = ['address', 'accepting', 'notes', 'seekingVolunteers']
 
 const hiddenSearchComponent = (field, value) => (
   `<p class="${field}" style="display:none">${value || '' }</p>`


### PR DESCRIPTION
<!-- 
  Does your pull request introduce changes to the mutual aid web app at? If so, use this
  checklist to ensure the project meets the needs.

  Has text been added that requires translations? If so, add the "Needs Translations" label
-->

### What
Set display of memorial day hours banner to none.

### Why
Not currently applicable. Setting to none rather than deleting in case we want to repurpose for the recently proposed "[take the survey banner".](https://tcmap.slack.com/archives/C017F4NDQAH/p1622515771041800?thread_ts=1622227336.032100&cid=C017F4NDQAH) 

### Ensure the following interactions work as expected. Please test using a mobile form factor.
- [x] Tapping on a marker on the map displays information about the marker in a popup.
- [x] Tapping the "Show list of locations" button replaces the map view with a list view.
- [x] Tapping an item in the list replaces the list view with a map view, and navigates the map to the tapped item on the map.
- [x] Tapping one of the ✅'s in the legend filters items on the map and in the list.
- [x] Changing the language to spanish changes things on the page.
- [x] Clicking the Help/Info button opens and closes a menu with information.
- [x] Clicking the X Close button on the Help/Info screen closes the modal.

### Check the app in the following web browsers:
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
